### PR TITLE
Update Sony - PlayStation 2.json

### DIFF
--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -656,7 +656,7 @@
 			["Disney Les Aventures de Porcinet", 1]
 		],
 		"Disney Think Fast": [
-			["Disney Otvechaj - ne zevaj!", 1]
+			["Disney Otvechaj-ne zevaj!", 1]
 		],
 		"Disney-Pixar Cars": [
 			["Disney-Pixar Bilar", 1]
@@ -687,6 +687,9 @@
 			["Disney-Pixar Los Increibles", 1],
 			["Disney-Pixar Die Unglaublichen", 1],
 			["Incredibles, The - Os Super-Herois", 1]
+		],
+		"Disney-Pixar Toy Story 3": [
+			["Disney-Pixar Istoriya Igrushek - Bol'shoj Pobeg", 1]
 		],
 		"Disney-Pixar Up": [
 			["Disney-Pixar Psila ston Ourano", 1],
@@ -2685,7 +2688,7 @@
 			["Digital Devil Saga - Avatar Tuner", 1]
 		],
 		"Shin Megami Tensei - Digital Devil Saga 2": [
-			["Digital Devil Saga - Avatar Tuner 2", 1]
+			["Digital Devil Saga 2 - Avatar Tuner", 1]
 		],
 		"Shin Megami Tensei - Nocturne": [
 			["Shin Megami Tensei III - Nocturne Maniax - Chronicle Edition", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -2403,6 +2403,7 @@
 			["Raging Bless - Hangma Muksirok", 1]
 		],
 		"Ratchet & Clank - Going Commando": [
+			["Ratchet & Clank - Gonggu Jeonsa Daebak Moli", 1],
 			["Ratchet & Clank 2", 1],
 			["Ratchet & Clank 2 - Gagaga! Ginga no Commando-ssu", 1]
 		],
@@ -2411,10 +2412,12 @@
 		],
 		"Ratchet - Deadlocked": [
 			["Ratchet - Gladiator", 1],
+			["Ratchet & Clank - Gonggu Jeonsa Wigi Ilbal", 1],
 			["Ratchet & Clank 4th - Giri Giri Ginga no Giga Battle (Special Gift Package)", 1],
 			["Ratchet & Clank 4th - Giri Giri Ginga no Giga Battle", 2]
 		],
 		"Ratchet & Clank - Up Your Arsenal": [
+			["Ratchet & Clank - Gonggu Jeonsa Reloaded", 1],
 			["Ratchet & Clank 3", 1],
 			["Ratchet & Clank 3 - Totsugeki! Galactic Rangers", 1]
 		],
@@ -2900,6 +2903,9 @@
 			["Star Wars - La Guerra dei Cloni", 1],
 			["Star Wars - Las Guerras Clon", 1]
 		],
+		"State of Emergency 2": [
+			["State of Emergency Revenge", 1]
+		],
 		"Steambot Chronicles": [
 			["Ponkotsu Roman Daikatsugeki - Bumpy Trot", 1],
 			["Action Romance Bumpy Trot", 1]
@@ -3226,6 +3232,9 @@
 		"Viewtiful Joe 2": [
 			["Viewtiful Joe 2 - Black Film no Nazo", 1]
 		],
+		"Virtua Cop - Elite Edition": [
+			["Virtua Cop Re-Birth", 1]
+		],
 		"Virtua Fighter - 10th Anniversary Edition": [
 			["Virtua Fighter - 10th Anniversary Fukkoku-ban", 1]
 		],
@@ -3265,6 +3274,9 @@
 		],
 		"Weakest Link, The": [
 			["Maillon Faible, Le", 1]
+		],
+		"Wallace & Gromit - The Curse of the Were-Rabbit": [
+			["Wallace to Gromit - Yasaibatake de Dai-Pinch!", 1]
 		],
 		"Way of the Samurai": [
 			["Samurai", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -224,6 +224,9 @@
 		"Armored Core - Last Raven": [
 			["Armored Core - Last Raven (Machine Side Box)", 1]
 		],
+		"Art of Fighting Anthology": [
+			["NeoGeo Online Collection Vol. 4 - Ryuuko no Ken - Ten Chi Jin", 1]
+		],
 		"Arthur and the Invisibles - The Game": [
 			["Arthur and the Minimoys", 1]
 		],
@@ -985,6 +988,9 @@
 		"Fatal Frame III - The Tormented": [
 			["Project Zero 3", 1],
 			["Zero - Shisei no Koe", 1]
+		],
+		"Fatal Fury - Battle Archives Volume 1": [
+			["NeoGeo Online Collection Vol. 5 - Garou Densetsu Battle Archives 1", 1]
 		],
 		"Fatal Fury - Battle Archives Volume 2": [
 			["NeoGeo Online Collection Vol. 6 - Garou Densetsu Battle Archives 2", 1]
@@ -2134,7 +2140,7 @@
 			["Nickelodeon Bob Esponja - La Pelicula", 1]
 		],
 		"Nicktoons - Attack of the Toybots": [
-			["Nickelodeon SpongeBob and Friends - Attack of the Toybots", 1]
+			["Nickelodeon SpongeBob and Friends - Attack of the Toybots", 0]
 		],
 		"Nicktoons - Battle for Volcano Island": [
 			["Nickelodeon SpongeBob and Friends - Battle for Volcano Island", 1]
@@ -2576,6 +2582,9 @@
 		"Samurai Shodown V": [
 			["Samurai Shodown Anthology", 0],
 			["Samurai Spirits Zero", 1]
+		],
+		"Samurai Shodown Anthology": [
+			["NeoGeo Online Collection Vol. 12 - Samurai Spirits - Rokuban Shoubu", 1]
 		],
 		"Samurai Spirits - Tenka-ichi Kenkakuden": [
 			["Samurai Shodown Anthology", 0]
@@ -3317,6 +3326,9 @@
 		],
 		"World Fighting": [
 			["Simple 2000 Series Vol. 42 - The Ishu Kakutougi", 1]
+		],
+		"World Heroes Anthology": [
+			["NeoGeo Online Collection Vol. 9 - World Heroes Gorgeous", 1]
 		],
 		"World of Outlaws - Sprint Cars 2002": [
 			["World of Outlaws - Sprint Cars", 1]

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -2141,7 +2141,7 @@
 			["Nickelodeon Bob Esponja - La Pelicula", 1]
 		],
 		"Nicktoons - Attack of the Toybots": [
-			["Nickelodeon SpongeBob and Friends - Attack of the Toybots", 0]
+			["Nickelodeon SpongeBob and Friends - Attack of the Toybots", 1]
 		],
 		"Nicktoons - Battle for Volcano Island": [
 			["Nickelodeon SpongeBob and Friends - Battle for Volcano Island", 1]

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -3,7 +3,7 @@
 		"name": [
 			"Sony - PlayStation 2"
 		],
-		"last updated": "21 October 2022",
+		"last updated": "23 October 2022",
 		"minimum version": "0.92"
 	},
 
@@ -282,6 +282,9 @@
 		],
 		"Berserk - Millennium Falcon-hen - Seima Senki no Shou": [
 			["Berserk - Millennium Falcon-hen - Seima Senki no Shou (Branded Box - Rakuin no Hako)", 2]
+		],
+		"Beta Bloc": [
+			["Simple 2000 Series Vol. 106 - The Block Kuzushi Quest - Dragon Kingdom", 1]
 		],
 		"Big Mutha Truckers": [
 			["Bakusou Convoy Densetsu - Otoko Hanamichi America Roman", 1]
@@ -686,7 +689,11 @@
 			["Disney-Pixar Gli Incredibili", 1],
 			["Disney-Pixar Los Increibles", 1],
 			["Disney-Pixar Die Unglaublichen", 1],
-			["Incredibles, The - Os Super-Herois", 1]
+			["Incredibles, The - Os Super-Herois", 1],
+			["Mr. Incredible", 1]
+		],
+		"Disney-Pixar The Incredibles - Rise of the Underminer": [
+			["Mr. Incredible - Kyouteki Underminer Toujou", 1]
 		],
 		"Disney-Pixar Toy Story 3": [
 			["Disney-Pixar Istoriya Igrushek - Bol'shoj Pobeg", 1]

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -2289,6 +2289,11 @@
 		"Party Girls": [
 			["Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no - The Suiei Taikai", 1]
 		],
+		"Persona 3 FES (Append-ban)": [
+			["Shin Megami Tensei - Persona 3 FES", 0],
+			["Persona 3 FES", 0],
+			["Yeosin Jeonsaeng Persona 3 FES", 0]
+		],
 		"PES 2008 - Pro Evolution Soccer": [
 			["World Soccer Winning Eleven 2008", 1]
 		],
@@ -2753,13 +2758,11 @@
 			["Shin Megami Tensei III - Nocturne (Deluxe Pack)", 4]
 		],
 		"Shin Megami Tensei - Persona 3": [
+			["Shin Megami Tensei - Persona 3 FES", 0],
+			["Persona 3 FES", 0],
+			["Yeosin Jeonsaeng Persona 3 FES", 0],
 			["P3 - Persona 3", 1],
 			["Persona 3", 1]
-		],
-		"Shin Megami Tensei - Persona 3 FES": [
-			["Persona 3 FES", 1],
-			["Persona 3 FES (Append-ban)", 1],
-			["Yeosin Jeonsaeng Persona 3 FES", 1]
 		],
 		"Shin Megami Tensei - Persona 4": [
 			["Persona 4", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -583,7 +583,8 @@
 			["Demo Disc Version 2.1 (Demo)", 2]
 		],
 		"Demolition Girl": [
-			["Simple 2000 Series Vol. 50 - The Daibijin", 1]
+			["Simple 2000 Series Vol. 50 - The Daibijin", 1],
+			["Simple 2000 Series - The Daemiin", 1]
 		],
 		"Demon Chaos": [
 			["Ikusagami", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -2246,9 +2246,6 @@
 		"Party Girls": [
 			["Simple 2000 Series Vol. 63 - Mogitate Mizugi! Onna Mamire no - The Suiei Taikai", 1]
 		],
-		"Persona 3 FES (Append-ban)": [
-			["Shin Megami Tensei - Persona 3 FES", 0]
-		],
 		"PES 2008 - Pro Evolution Soccer": [
 			["World Soccer Winning Eleven 2008", 1]
 		],
@@ -2700,10 +2697,12 @@
 			["Shin Megami Tensei III - Nocturne (Deluxe Pack)", 4]
 		],
 		"Shin Megami Tensei - Persona 3": [
-			["Shin Megami Tensei - Persona 3 FES", 0],
-			["Persona 3 FES", 0],
 			["P3 - Persona 3", 1],
 			["Persona 3", 1]
+		],
+		"Shin Megami Tensei - Persona 3 FES": [
+			["Persona 3 FES", 1],
+			["Persona 3 FES (Append-ban)", 1]
 		],
 		"Shin Megami Tensei - Persona 4": [
 			["Persona 4", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -3,7 +3,7 @@
 		"name": [
 			"Sony - PlayStation 2"
 		],
-		"last updated": "23 October 2022",
+		"last updated": "19 november 2022",
 		"minimum version": "0.92"
 	},
 
@@ -658,6 +658,9 @@
 			["Disney Pimpi, Piccolo Grande Eroe", 1],
 			["Disney Les Aventures de Porcinet", 1]
 		],
+		"Disney Princess - Enchanted Journey": [
+			["Disney Princess - Mahou no Sekai e", 1]
+		],
 		"Disney Think Fast": [
 			["Disney Otvechaj-ne zevaj!", 1]
 		],
@@ -684,6 +687,9 @@
 			["Disney-Pixar Monstres & Cie - L'ile de l'Epouvante", 1],
 			["Disney-Pixar Monstruos, S.A. - Isla de los Sustos", 1],
 			["Disney-Pixar Die Monster AG - Schreckens-Insel", 1]
+		],
+		"Disney-Pixar Ratatouille": [
+			["Disney-Pixar Remy no Oishii Restaurant", 1]
 		],
 		"Disney-Pixar The Incredibles": [
 			["Disney-Pixar Gli Incredibili", 1],
@@ -722,6 +728,9 @@
 		],
 		"Disney's PK - Out of the Shadows": [
 			["Disney's Donald Duck PK", 1]
+		],
+		"Disney's Stitch - Experiment 626": [
+			["Disney's Lilo and Stitch - Stitch no Daibouken", 1]
 		],
 		"Disney's Tarzan - Untamed": [
 			["Disney's Tarzan - Freeride", 1]
@@ -1150,6 +1159,9 @@
 		"Frogger Beyond": [
 			["Frogger", 1]
 		],
+		"Frogger's Adventures - The Rescue": [
+			["Frogger Rescue", 1]
+		],
 		"Fugitive Hunter - War on Terror": [
 			["10 Most Wanted", 1],
 			["America's 10 Most Wanted", 1]
@@ -1456,6 +1468,9 @@
 			["Legend of Sayuki", 1],
 			["Yukinko Daisenpuu - Sayuki to Koyuki no Hie Hie Daisoudou", 1]
 		],
+		"Hello Kitty - Roller Rescue": [
+			["Hello Kitty no PikoPiko Daisakusen", 1]
+		],
 		"Higurashi no Naku Koro ni - Matsuri - Kakera Asobi (Append-ban)": [
 			["Higurashi no Naku Koro ni - Matsuri - Kakera Asobi", 0]
 		],
@@ -1466,7 +1481,8 @@
 			["Hitman - Silent Assassin", 1]
 		],
 		"Hobbit, The - The Prelude to the Lord of the Rings": [
-			["Hobbit - Predystoriya Sagi Vlastelin Kolets", 1]
+			["Hobbit - Predystoriya Sagi Vlastelin Kolets", 1],
+			["Hobbit no Bouken - Lord of the Rings - Hajimari no Monogatari", 1]
 		],
 		"Horsez": [
 			["Pippa Funnell - Take the Reins", 1]
@@ -1759,6 +1775,7 @@
 		"LMA Manager 2005": [
 			["BDFL Manager 2005", 1],
 			["Football Manager Campionato 2005", 1],
+			["LMA Manager 2005 (SLES-53149)", 2],
 			["Manager de Liga 2005", 1],
 			["Roger Lemerre - La Selection des Champions 2005", 1]
 		],
@@ -2897,6 +2914,9 @@
 		"Spectral Force Chronicle (10-shuunen Kinen Box)": [
 			["Spectral Force Chronicle", 2]
 		],
+		"SpinDrive Ping Pong": [
+			["Fukuhara Ai no Takkyuu Icchokusen", 1]
+		],
 		"Splashdown - Rides Gone Wild": [
 			["Splashdown 2 - Rides Gone Wild", 1]
 		],
@@ -3274,6 +3294,9 @@
 		],
 		"Waga Ryuu o Miyo - Pride of the Dragon Peace": [
 			["Kan Wo Long Xian Shen Wei", 1]
+		],
+		"Walt Disney Pictures Presents Meet the Robinsons": [
+			["Lewis to Mirai Dorobou - Wilbur no Kiken na Jikan Ryokou", 1]
 		],
 		"Walt Disney's The Jungle Book - Rhythm n' Groove": [
 			["Walt Disney's The Jungle Book - Groove Party", 1]

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -1772,11 +1772,12 @@
 			["Manager de Liga 2004", 1],
 			["Roger Lemerre - La Selection des Champions 2004", 1]
 		],
-		"LMA Manager 2005": [
+		"LMA Manager 2005 (SLES-53149)": [
 			["BDFL Manager 2005", 1],
 			["Football Manager Campionato 2005", 1],
-			["LMA Manager 2005 (SLES-53149)", 2],
+			["LMA Manager 2005", 2],
 			["Manager de Liga 2005", 1],
+			["Manchester United Manager 2005", 1],
 			["Roger Lemerre - La Selection des Champions 2005", 1]
 		],
 		"London Racer II": [

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -3,7 +3,7 @@
 		"name": [
 			"Sony - PlayStation 2"
 		],
-		"last updated": "19 november 2022",
+		"last updated": "20 november 2022",
 		"minimum version": "0.92"
 	},
 
@@ -221,6 +221,9 @@
 		"Army Men - Air Attack 2": [
 			["Army Men - Air Attack - Blade's Revenge", 1]
 		],
+		"Army Men - RTS": [
+			["Totsugeki! Army Men - Shijou Saishou no Sakusen", 1]
+		],
 		"Armored Core - Last Raven": [
 			["Armored Core - Last Raven (Machine Side Box)", 1]
 		],
@@ -267,6 +270,9 @@
 		],
 		"Bad Boys - Miami Takedown": [
 			["Bad Boys II", 1]
+		],
+		"Barbarian": [
+			["Warrior Blade - Rastan vs. Barbarian-hen", 1]
 		],
 		"Basketball Xciting": [
 			["Simple 2000 Series Vol. 30 - The Street Basketball - 3 on 3", 1]
@@ -1706,10 +1712,6 @@
 		"Kyou kara Maou! Hajimari no Tabi (Premium Box)": [
 			["Kyou kara Maou! Hajimari no Tabi", 2]
 		],
-		"La Pucelle - Tactics": [
-			["La Pucelle - Hikari no Seijo Densetsu", 1],
-			["La Pucelle - Hikari no Seijo Densetsu - 2-shuume Hajimemashita.", 2]
-		],
 		"Lara Croft Tomb Raider - The Angel of Darkness": [
 			["Lara Croft Tomb Raider - Utsukushiki Toubousha", 1]
 		],
@@ -2386,6 +2388,9 @@
 		"Prince of Persia - The Sands of Time": [
 			["Prince of Persia - Jikan no Suna", 1]
 		],
+		"Prince of Persia - The Two Thrones": [
+			["Prince of Persia - Futatsu no Tamashii", 1]
+		],
 		"Prince of Persia - Warrior Within": [
 			["Prince of Persia - Kenshi no Kokoro", 1]
 		],
@@ -2414,6 +2419,10 @@
 		],
 		"Psi-Ops - The Mindgate Conspiracy": [
 			["Psi-Ops - Psychic Operation", 1]
+		],
+		"Pucelle, La - Hikari no Seijo Densetsu - 2-shuume Hajimemashita": [
+			["Pucelle, La - Hikari no Seijo Densetsu", 2],
+			["Pucelle, La - Tactics", 1]
 		],
 		"Puyo Pop Fever": [
 			["Puyo Puyo Fever", 1]
@@ -2527,6 +2536,9 @@
 		],
 		"Road Trip": [
 			["Road Trip Adventure", 1]
+		],
+		"RoboCop": [
+			["RoboCop - Aratanaru Kiki", 1]
 		],
 		"Robot Alchemic Drive": [
 			["Gigantic Drive", 1]
@@ -2746,7 +2758,8 @@
 		],
 		"Shin Megami Tensei - Persona 3 FES": [
 			["Persona 3 FES", 1],
-			["Persona 3 FES (Append-ban)", 1]
+			["Persona 3 FES (Append-ban)", 1],
+			["Yeosin Jeonsaeng Persona 3 FES", 1]
 		],
 		"Shin Megami Tensei - Persona 4": [
 			["Persona 4", 1],
@@ -3190,6 +3203,9 @@
 		"Tony Hawk's Pro Skater 4": [
 			["Tony Hawk's Pro Skater 2003", 1]
 		],
+		"Top Angler": [
+			["Real Bass Fishing - Top Angler", 1]
+		],
 		"Top Gear Dare Devil": [
 			["TG DareDevil", 1]
 		],
@@ -3352,6 +3368,9 @@
 		],
 		"Wild Arms 5": [
 			["Wild Arms - The Vth Vanguard", 1]
+		],
+		"Wild Water Adrenaline featuring Salomon": [
+			["River Ride Adventure featuring Salomon", 1]
 		],
 		"WinBack - Covert Operations": [
 			["Operation WinBack", 1],

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -3,7 +3,7 @@
 		"name": [
 			"Sony - PlayStation 2"
 		],
-		"last updated": "18 September 2022",
+		"last updated": "21 October 2022",
 		"minimum version": "0.92"
 	},
 
@@ -1095,6 +1095,9 @@
 			["Bass Master Fishing", 1],
 			["Simple 2000 Series Vol. 3 - The Bass Fishing", 1]
 		],
+		"Fishing Fantasy - Buzzrod": [
+			["BuzzRod - Fishing Fantasy", 1]
+		],
 		"Fitness Fun": [
 			["Simple 2000 Series Ultimate Vol. 18 - Love - Aerobi", 1]
 		],
@@ -1352,6 +1355,9 @@
 		"Gungrave - Overdose": [
 			["Gungrave O.D.", 1]
 		],
+		"Hajime no Ippo 2 - Victorious Road": [
+			["Hajime-ui Ilbo 2 - Victorious Road", 1]
+		],
 		"Hanjuku Hero 4 - 7-nin no Hanjuku Hero": [
 			["Hanjuku Hero 4 - 7-nin no Hanjuku Hero (Ginga Hanjuku Bentou)", 0]
 		],
@@ -1482,6 +1488,9 @@
 			["Era Glaciale 3, L' - L'Alba dei Dinosauri", 1],
 			["Ice Age 3 - Dawn of the Dinosaurs", 1]
 		],
+		"Ice Age 2 - The Meltdown": [
+			["Ice Age 2", 1]
+		],
 		"Ichigeki Satchuu!! Hoihoi-san": [
 			["Ilgyeok Salchung!! Hoihoi-san", 1]
 		],
@@ -1595,6 +1604,9 @@
 		],
 		"Karaoke Revolution Party": [
 			["Karaoke Stage 2", 1]
+		],
+		"Katamari Damacy": [
+			["Goehon - Gulryeora! Wangjanim!", 1]
 		],
 		"Kelly Slater's Pro Surfer": [
 			["Kelly Slater's Pro Surfer 2003", 1]
@@ -2817,6 +2829,9 @@
 		"Sly 3 - Honor Among Thieves": [
 			["Sly 3 - Honour Among Thieves", 1]
 		],
+		"Smash Cars": [
+			["Buggy Grand Prix - Kattobi! Daisakusen", 1]
+		],
 		"Smash Court Tennis - Pro Tournament": [
 			["Smash Court Pro Tournament", 1]
 		],
@@ -3255,6 +3270,9 @@
 		],
 		"Walt Disney's The Jungle Book - Rhythm n' Groove": [
 			["Walt Disney's The Jungle Book - Groove Party", 1]
+		],
+		"War of the Monsters": [
+			["Kaijuu Daigekisen - War of the Monsters", 1]
 		],
 		"Warriors Orochi": [
 			["Musou Orochi", 1]

--- a/clonelists/Sony - PlayStation 2.json
+++ b/clonelists/Sony - PlayStation 2.json
@@ -3,7 +3,7 @@
 		"name": [
 			"Sony - PlayStation 2"
 		],
-		"last updated": "28 August 2022",
+		"last updated": "18 September 2022",
 		"minimum version": "0.92"
 	},
 
@@ -2898,7 +2898,8 @@
 			["Star Wars - Las Guerras Clon", 1]
 		],
 		"Steambot Chronicles": [
-			["Ponkotsu Roman Daikatsugeki - Bumpy Trot", 1]
+			["Ponkotsu Roman Daikatsugeki - Bumpy Trot", 1],
+			["Action Romance Bumpy Trot", 1]
 		],
 		"Steel Dragon EX": [
 			["Simple 2000 Series Vol. 37 - The Shooting - Double Shienryuu", 1]


### PR DESCRIPTION
About "Attack of the Toybots":
`Nicktoons - Attack of the Toybots` is an english only release for the PAL zone (both EU and AUS) but `Nickelodeon SpongeBob and Friends - Attack of the Toybots` is a Multi6 release for Europe (no Australia but it's exactly the same game, minus the title screen). Retool only takes the `Nicktoons` instead of the other one with the previous setting (treating `Nickelodeon SpongeBob and Friends - Attack of the Toybots` as a regional equivalent)... What I'm trying to do here, by putting 0 in the line of `Nickelodeon SpongeBob and Friends - Attack of the Toybots` is to give this release the priority because any PAL player can give this one a go instead of `Nicktoons` which is english only.