### PR TITLE
Updated language for Circus Charlie, due to being incorrectly set as japanese.

### DIFF
--- a/metadata/Microsoft - MSX (No-Intro).json
+++ b/metadata/Microsoft - MSX (No-Intro).json
@@ -522,7 +522,7 @@
 		"languages": ["Ja"]
 	},
 	"Circus Charlie (Japan) (Wii U Virtual Console)": {
-		"languages": ["Ja"]
+		"languages": ["En"]
 	},
 	"City Connection (Japan) (Alt)": {
 		"languages": ["Ja"]


### PR DESCRIPTION
Circus Charlie for Wii U does contain english only.