### PR TITLE
Create Nintendo Wii U (Redump).json that match against No-Intro DAT Nintendo - Wii U - WUX (513) (2023-04-30)

### DIFF
--- a/clonelists/Nintendo - Wii U (Redump).json
+++ b/clonelists/Nintendo - Wii U (Redump).json
@@ -1,0 +1,196 @@
+{
+	"description": {
+		"name": "Nintendo - Wii U (Redump)",
+		"lastUpdated": "6 July 2023",
+		"minimumVersion": "2.00"
+	},
+
+	"categories": [		
+		{
+		  "searchTerm": "83178 - DISC, CAT-I RTL MAR '14 USA-PT",
+		  "nameType": "short",
+		  "categories": ["Demos"]
+		}
+	  ],	
+
+	"variants": [
+		{
+			"group": "Animal Crossing - Amiibo Festival",
+			"titles": [
+				{"searchTerm": "Animal Crossing - Amiibo Festival"},
+				{"searchTerm": "Doubutsu no Mori - Amiibo Festival"}
+			]
+		},			
+		{
+			"group": "Batman - Arkham City - Armored Edition",
+			"titles": [
+				{"searchTerm": "Batman - Arkham City - Armored Edition"},
+				{"searchTerm": "Batman - Arkham City - Armoured Edition"}
+			]
+		},			
+		{
+			"group": "Disney Epic Mickey 2 - The Power of Two",
+			"titles": [
+				{"searchTerm": "Disney Epic Mickey 2 - The Power of Two"},
+				{"searchTerm": "Disney Epic Mickey 2 - Futatsu no Chikara"}
+			]
+		},	
+		{
+			"group": "Disney Infinity 2.0 Edition",
+			"titles": [
+				{"searchTerm": "Disney Infinity 2.0 Edition"},
+				{"searchTerm": "Disney Infinity 2.0 - Play Without Limits"}
+			]
+		},	
+		{
+			"group": "Disney Infinity 3.0 Edition",
+			"titles": [
+				{"searchTerm": "Disney Infinity 3.0 Edition"},
+				{"searchTerm": "Disney Infinity 3.0 - Play Without Limits"},
+				{"searchTerm": "Disney Infinity 3.0"}
+			]
+		},							
+		{
+			"group": "FIFA Soccer 13",
+			"titles": [
+				{"searchTerm": "FIFA Soccer 13"},
+				{"searchTerm": "FIFA 13"},
+				{"searchTerm": "FIFA 13 - World Class Soccer"}
+			]
+		},		
+		{
+			"group": "Hyrule Warriors",
+			"titles": [
+				{"searchTerm": "Hyrule Warriors"},
+				{"searchTerm": "Zelda Musou"}
+			]
+		},
+		{
+			"group": "Injustice - Gods Among Us",
+			"titles": [
+				{"searchTerm": "Injustice - Gods Among Us"},
+				{"searchTerm": "Injustice - Hero no Gekitotsu"}
+			]
+		},						
+		{
+			"group": "Need for Speed - Most Wanted U",
+			"titles": [
+				{"searchTerm": "Need for Speed - Most Wanted U"},
+				{"searchTerm": "Need for Speed - Most Wanted U - A Criterion Game"},
+				{"searchTerm": "Need for Speed - Most Wanted U - A Criterion Game"}
+			]
+		},
+		{
+			"group": "Legend of Zelda, The - The Wind Waker HD",
+			"titles": [
+				{"searchTerm": "Legend of Zelda, The - Twilight Princess HD"},
+				{"searchTerm": "Zelda no Densetsu - Kaze no Takuto HD"}
+			]
+		},			
+		{
+			"group": "Legend of Zelda, The - Twilight Princess HD",
+			"titles": [
+				{"searchTerm": "Legend of Zelda, The - Twilight Princess HD"},
+				{"searchTerm": "Zelda no Densetsu - Twilight Princess HD"}
+			]
+		},
+		{
+			"group": "LEGO Batman 3 - Beyond Gotham",
+			"titles": [
+				{"searchTerm": "LEGO Batman 3 - Beyond Gotham"},
+				{"searchTerm": "LEGO Batman 3 - The Game - Gotham kara Uchuu e"}
+			]
+		},			
+		{
+			"group": "LEGO Marvel Super Heroes",
+			"titles": [
+				{"searchTerm": "LEGO Marvel Super Heroes"},
+				{"searchTerm": "LEGO Marvel Super Heroes - The Game"}
+			]
+		},			
+		{
+			"group": "LEGO Movie, The - Videogame",
+			"titles": [
+				{"searchTerm": "LEGO Movie, The - Videogame"},
+				{"searchTerm": "LEGO Movie - The Game"}
+			]
+		},		
+		{
+			"group": "LEGO Star Wars - The Force Awakens",
+			"titles": [
+				{"searchTerm": "LEGO Star Wars - The Force Awakens"},
+				{"searchTerm": "LEGO Star Wars - Force no Kakusei"}
+			]
+		},			
+		{
+			"group": "Mario & Sonic at the Rio 2016 Olympic Games",
+			"titles": [
+				{"searchTerm": "Mario & Sonic at the Rio 2016 Olympic Games"},
+				{"searchTerm": "Mario & Sonic at Rio Olympic"}
+			]
+		},			
+		{
+			"group": "Mario & Sonic at the Sochi 2014 Olympic Winter Games",
+			"titles": [
+				{"searchTerm": "Mario & Sonic at the Sochi 2014 Olympic Winter Games"},
+				{"searchTerm": "Mario & Sonic at the Sochi Olympic"}
+			]
+		},		
+		{
+			"group": "Mass Effect 3 - Special Edition",
+			"titles": [
+				{"searchTerm": "Mass Effect 3 - Special Edition"},
+				{"searchTerm": "Mass Effect 3 - Tokubetsu-ban"}
+			]
+		},		
+		{
+			"group": "One Piece - Unlimited World Red",
+			"titles": [
+				{"searchTerm": "One Piece - Unlimited World Red"},
+				{"searchTerm": "One Piece - Unlimited World R"}
+			]
+		},		
+		{
+			"group": "Pokken Tournament",
+			"titles": [
+				{"searchTerm": "Pokken Tournament"},
+				{"searchTerm": "Pokken - Pokken Tournament"}
+			]
+		},					
+		{
+			"group": "Project Zero - Maiden of Black Water",
+			"titles": [
+				{"searchTerm": "Project Zero - Maiden of Black Water"},
+				{"searchTerm": "Zero - Nuregarasu no Miko"}
+			]
+		},
+		{
+			"group": "Resident Evil - Revelations",
+			"titles": [
+				{"searchTerm": "Resident Evil - Revelations"},
+				{"searchTerm": "Biohazard - Revelations - Unveiled Edition"}
+			]
+		},		
+		{
+			"group": "Sangokushi 12",
+			"titles": [
+				{"searchTerm": "Sangokushi 12"},
+				{"searchTerm": "Sangokushi 12 with Power-Up Kit"}
+			]
+		},
+		{
+			"group": "Xenoblade Chronicles X",
+			"titles": [
+				{"searchTerm": "Xenoblade Chronicles X"},
+				{"searchTerm": "Xenoblade X"}
+			]
+		},		
+		{
+			"group": "Yoshi's Woolly World",
+			"titles": [
+				{"searchTerm": "Yoshi's Woolly World"},
+				{"searchTerm": "Yoshi Wool World"}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Created `Nintendo - Wii U (Redump).json` that removes clonelist for mostly Japanese games. It is matched against NO-INTRO DAT `Nintendo - Wii U - WUX (513) (2023-04-30).dat`, which includeds `.wux` roms.