### PR TITLE
Create Nintendo Wii U (Redump).json and Sony - PlayStation Vita (PSN) (Content) (No-Intro).json

### DIFF
--- a/clonelists/Nintendo - Wii U (Redump).json
+++ b/clonelists/Nintendo - Wii U (Redump).json
@@ -1,0 +1,196 @@
+{
+	"description": {
+		"name": "Nintendo - Wii U (Redump)",
+		"lastUpdated": "6 July 2023",
+		"minimumVersion": "2.00"
+	},
+
+	"categories": [		
+		{
+		  "searchTerm": "83178 - DISC, CAT-I RTL MAR '14 USA-PT",
+		  "nameType": "short",
+		  "categories": ["Demos"]
+		}
+	  ],	
+
+	"variants": [
+		{
+			"group": "Animal Crossing - Amiibo Festival",
+			"titles": [
+				{"searchTerm": "Animal Crossing - Amiibo Festival"},
+				{"searchTerm": "Doubutsu no Mori - Amiibo Festival"}
+			]
+		},			
+		{
+			"group": "Batman - Arkham City - Armored Edition",
+			"titles": [
+				{"searchTerm": "Batman - Arkham City - Armored Edition"},
+				{"searchTerm": "Batman - Arkham City - Armoured Edition"}
+			]
+		},			
+		{
+			"group": "Disney Epic Mickey 2 - The Power of Two",
+			"titles": [
+				{"searchTerm": "Disney Epic Mickey 2 - The Power of Two"},
+				{"searchTerm": "Disney Epic Mickey 2 - Futatsu no Chikara"}
+			]
+		},	
+		{
+			"group": "Disney Infinity 2.0 Edition",
+			"titles": [
+				{"searchTerm": "Disney Infinity 2.0 Edition"},
+				{"searchTerm": "Disney Infinity 2.0 - Play Without Limits"}
+			]
+		},	
+		{
+			"group": "Disney Infinity 3.0 Edition",
+			"titles": [
+				{"searchTerm": "Disney Infinity 3.0 Edition"},
+				{"searchTerm": "Disney Infinity 3.0 - Play Without Limits"},
+				{"searchTerm": "Disney Infinity 3.0"}
+			]
+		},							
+		{
+			"group": "FIFA Soccer 13",
+			"titles": [
+				{"searchTerm": "FIFA Soccer 13"},
+				{"searchTerm": "FIFA 13"},
+				{"searchTerm": "FIFA 13 - World Class Soccer"}
+			]
+		},		
+		{
+			"group": "Hyrule Warriors",
+			"titles": [
+				{"searchTerm": "Hyrule Warriors"},
+				{"searchTerm": "Zelda Musou"}
+			]
+		},
+		{
+			"group": "Injustice - Gods Among Us",
+			"titles": [
+				{"searchTerm": "Injustice - Gods Among Us"},
+				{"searchTerm": "Injustice - Hero no Gekitotsu"}
+			]
+		},						
+		{
+			"group": "Need for Speed - Most Wanted U",
+			"titles": [
+				{"searchTerm": "Need for Speed - Most Wanted U"},
+				{"searchTerm": "Need for Speed - Most Wanted U - A Criterion Game"},
+				{"searchTerm": "Need for Speed - Most Wanted U - A Criterion Game"}
+			]
+		},
+		{
+			"group": "Legend of Zelda, The - The Wind Waker HD",
+			"titles": [
+				{"searchTerm": "Legend of Zelda, The - Twilight Princess HD"},
+				{"searchTerm": "Zelda no Densetsu - Kaze no Takuto HD"}
+			]
+		},			
+		{
+			"group": "Legend of Zelda, The - Twilight Princess HD",
+			"titles": [
+				{"searchTerm": "Legend of Zelda, The - Twilight Princess HD"},
+				{"searchTerm": "Zelda no Densetsu - Twilight Princess HD"}
+			]
+		},
+		{
+			"group": "LEGO Batman 3 - Beyond Gotham",
+			"titles": [
+				{"searchTerm": "LEGO Batman 3 - Beyond Gotham"},
+				{"searchTerm": "LEGO Batman 3 - The Game - Gotham kara Uchuu e"}
+			]
+		},			
+		{
+			"group": "LEGO Marvel Super Heroes",
+			"titles": [
+				{"searchTerm": "LEGO Marvel Super Heroes"},
+				{"searchTerm": "LEGO Marvel Super Heroes - The Game"}
+			]
+		},			
+		{
+			"group": "LEGO Movie, The - Videogame",
+			"titles": [
+				{"searchTerm": "LEGO Movie, The - Videogame"},
+				{"searchTerm": "LEGO Movie - The Game"}
+			]
+		},		
+		{
+			"group": "LEGO Star Wars - The Force Awakens",
+			"titles": [
+				{"searchTerm": "LEGO Star Wars - The Force Awakens"},
+				{"searchTerm": "LEGO Star Wars - Force no Kakusei"}
+			]
+		},			
+		{
+			"group": "Mario & Sonic at the Rio 2016 Olympic Games",
+			"titles": [
+				{"searchTerm": "Mario & Sonic at the Rio 2016 Olympic Games"},
+				{"searchTerm": "Mario & Sonic at Rio Olympic"}
+			]
+		},			
+		{
+			"group": "Mario & Sonic at the Sochi 2014 Olympic Winter Games",
+			"titles": [
+				{"searchTerm": "Mario & Sonic at the Sochi 2014 Olympic Winter Games"},
+				{"searchTerm": "Mario & Sonic at the Sochi Olympic"}
+			]
+		},		
+		{
+			"group": "Mass Effect 3 - Special Edition",
+			"titles": [
+				{"searchTerm": "Mass Effect 3 - Special Edition"},
+				{"searchTerm": "Mass Effect 3 - Tokubetsu-ban"}
+			]
+		},		
+		{
+			"group": "One Piece - Unlimited World Red",
+			"titles": [
+				{"searchTerm": "One Piece - Unlimited World Red"},
+				{"searchTerm": "One Piece - Unlimited World R"}
+			]
+		},		
+		{
+			"group": "Pokken Tournament",
+			"titles": [
+				{"searchTerm": "Pokken Tournament"},
+				{"searchTerm": "Pokken - Pokken Tournament"}
+			]
+		},					
+		{
+			"group": "Project Zero - Maiden of Black Water",
+			"titles": [
+				{"searchTerm": "Project Zero - Maiden of Black Water"},
+				{"searchTerm": "Zero - Nuregarasu no Miko"}
+			]
+		},
+		{
+			"group": "Resident Evil - Revelations",
+			"titles": [
+				{"searchTerm": "Resident Evil - Revelations"},
+				{"searchTerm": "Biohazard - Revelations - Unveiled Edition"}
+			]
+		},		
+		{
+			"group": "Sangokushi 12",
+			"titles": [
+				{"searchTerm": "Sangokushi 12"},
+				{"searchTerm": "Sangokushi 12 with Power-Up Kit"}
+			]
+		},
+		{
+			"group": "Xenoblade Chronicles X",
+			"titles": [
+				{"searchTerm": "Xenoblade Chronicles X"},
+				{"searchTerm": "Xenoblade X"}
+			]
+		},		
+		{
+			"group": "Yoshi's Woolly World",
+			"titles": [
+				{"searchTerm": "Yoshi's Woolly World"},
+				{"searchTerm": "Yoshi Wool World"}
+			]
+		}
+	]
+}

--- a/clonelists/Sony - PlayStation Vita (PSN) (Content) (No-Intro).json
+++ b/clonelists/Sony - PlayStation Vita (PSN) (Content) (No-Intro).json
@@ -1,0 +1,1550 @@
+{
+	"description": {
+		"name": "Sony - PlayStation Vita (PSN) (Content) (No-Intro)",
+		"lastUpdated": "9 July 2023",
+		"minimumVersion": "2.00"
+	},
+
+	"categories": [	
+		{
+			"searchTerm": "Amnesia World AR",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},
+		{
+			"searchTerm": "Crunchyroll",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "Facebook",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},								
+		{
+		  "searchTerm": "Gravity Rush - Maid Pack",
+		  "nameType": "short",
+		  "categories": ["Add-Ons"]
+		},
+		{
+			"searchTerm": "Gravity Rush - Special Forces Pack",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},
+		{
+			"searchTerm": "Gravity Rush - Spy Pack",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},		
+		{
+			"searchTerm": "Hatsune Miku - Project Diva F - Sync Tool",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},	
+		{
+			"searchTerm": "Killzone - Mercenary - Digital Art Book",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},
+		{
+			"searchTerm": "Live from PlayStation",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "LiveTweet",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "Netflix",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "Network Media Player",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},		
+		{
+			"searchTerm": "NHK On-Demand",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},			
+		{
+			"searchTerm": "NHL GameCenter",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "Niconico",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},		
+		{
+			"searchTerm": "PlayStation Home Arcade",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},		
+		{
+			"searchTerm": "PlayStation Mobile Development Assistant",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "PlayStation Mobile Runtime Package",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "PocketStation",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "Resistance - Burning Skies - Augmented Reality Monument Viewer",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},	
+		{
+			"searchTerm": "Robotics;Notes Elite AR",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		},		
+		{
+			"searchTerm": "Skype",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},			
+		{
+			"searchTerm": "Torne",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},		
+		{
+			"searchTerm": "Tsutaya TV",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "Tuenti",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "TuneIn Radio",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "TV Dogatchi",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "Twitch",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},
+		{
+			"searchTerm": "Uke-Torne",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},	
+		{
+			"searchTerm": "U-Next",
+			"nameType": "short",
+			"categories": ["Applications"]
+		},		
+		{
+			"searchTerm": "WipEout 2048 - Online Pass",
+			"nameType": "short",
+			"categories": ["Add-Ons"]
+		}																		
+	  ],	
+
+	"removes": [		
+	],
+
+	"variants": [
+		{
+			"group": "A-Men",
+			"titles": [
+				{"searchTerm": "A-Men"},
+				{"searchTerm": "Assault Armies"}
+			]
+		},		
+		{
+			"group": "Accel World vs. Sword Art Online",
+			"titles": [
+				{"searchTerm": "Accel World vs. Sword Art Online"},
+				{"searchTerm": "Accel World vs. Sword Art Online - Millennium Twilight"}
+			]
+		},				
+		{
+			"group": "Aegis of Earth - Protonovus Assault",
+			"titles": [
+				{"searchTerm": "Aegis of Earth - Protonovus Assault"},
+				{"searchTerm": "Zettai Geigeki Wars"}
+			]
+		},
+		{
+			"group": "Ar Nosurge Plus - Ode to an Unborn Star",
+			"titles": [
+				{"searchTerm": "Ar Nosurge Plus - Ode to an Unborn Star"},
+				{"searchTerm": "Ar Nosurge Plus - Umareizuru Hoshi e Inoru Uta"}
+			]
+		},	
+		{
+			"group": "Assassin's Creed III - Liberation",
+			"titles": [
+				{"searchTerm": "Assassin's Creed III - Liberation"},
+				{"searchTerm": "Assassin's Creed III - Lady Liberty"}
+			]
+		},	
+		{
+			"group": "Atelier Ayesha Plus - The Alchemist of Dusk",
+			"titles": [
+				{"searchTerm": "Atelier Ayesha Plus - The Alchemist of Dusk"},
+				{"searchTerm": "Ayesha no Atelier Plus - Koukon no Daichi no Renkinjutsu"}
+			]
+		},	
+		{
+			"group": "Atelier Escha & Logy Plus - Alchemists of the Dusk Sky",
+			"titles": [
+				{"searchTerm": "Atelier Escha & Logy Plus - Alchemists of the Dusk Sky"},
+				{"searchTerm": "Escha & Logy no Atelier Plus - Tasogare no Sora no Renkinjutsushi"}
+			]
+		},		
+		{
+			"group": "Atelier Firis - The Alchemist and the Mysterious Journey",
+			"titles": [
+				{"searchTerm": "Atelier Firis - The Alchemist and the Mysterious Journey"},
+				{"searchTerm": "Firis no Atelier - Fushigi na Tabi no Renkinjutsushi"}
+			]
+		},	
+		{
+			"group": "Atelier Meruru Plus - The Apprentice of Arland",
+			"titles": [
+				{"searchTerm": "Atelier Meruru Plus - The Apprentice of Arland"},
+				{"searchTerm": "Meruru no Atelier Plus - Arland no Renkinjutsushi 3"}
+			]
+		},												
+		{
+			"group": "Atelier Rorona Plus - The Alchemist of Arland",
+			"titles": [
+				{"searchTerm": "Atelier Rorona Plus - The Alchemist of Arland"},
+				{"searchTerm": "Shin Rorona no Atelier - Hajimari no Monogatari - Arland no Renkinjutsushi"}
+			]
+		},		
+		{
+			"group": "Atelier Shallie Plus - Alchemists of the Dusk Sea",
+			"titles": [
+				{"searchTerm": "Atelier Shallie Plus - Alchemists of the Dusk Sea"},
+				{"searchTerm": "Shallie no Atelier Plus - Tasogare no Umi no Renkinjutsushi"}
+			]
+		},
+		{
+			"group": "Atelier Sophie - The Alchemist of the Mysterious Book",
+			"titles": [
+				{"searchTerm": "Atelier Sophie - The Alchemist of the Mysterious Book"},
+				{"searchTerm": "Atelier Sophie - Fushigi na Hon no Renkinjutsushi"},
+				{"searchTerm": "Sophie no Atelier - Fushigi na Hon no Renkinjutsushi"}
+			]
+		},
+		{
+			"group": "Atelier Totori Plus - The Adventurer of Arland",
+			"titles": [
+				{"searchTerm": "Atelier Totori Plus - The Adventurer of Arland"},
+				{"searchTerm": "Totori no Atelier Plus - Arland no Renkinjutsushi 2"}
+			]
+		},	
+		{
+			"group": "Citizens of Earth",
+			"titles": [
+				{"searchTerm": "Citizens of Earth"},
+				{"searchTerm": "Citizens of Earth - Tatakae! Fukudaitouryou to 40-nin no Shimintachi!"}
+			]
+		},	
+		{
+			"group": "Cladun Returns - This Is Sengoku!",
+			"titles": [
+				{"searchTerm": "Cladun Returns - This Is Sengoku!"},
+				{"searchTerm": "Classic Dungeon Sengoku"}
+			]
+		},	
+		{
+			"group": "Code - Realize - Future Blessings",
+			"titles": [
+				{"searchTerm": "Code - Realize - Future Blessings"},
+				{"searchTerm": "Code - Realize - Shukufu no Mirai"}
+			]
+		},	
+		{
+			"group": "Code - Realize - Guardian of Rebirth",
+			"titles": [
+				{"searchTerm": "Code - Realize - Guardian of Rebirth"},
+				{"searchTerm": "Code - Realize - Sousei no Himegimi"}
+			]
+		},	
+		{
+			"group": "Code - Realize - Wintertide Miracles",
+			"titles": [
+				{"searchTerm": "Code - Realize - Wintertide Miracles"},
+				{"searchTerm": "Code - Realize - Shirogane no Kiseki"}
+			]
+		},	
+		{
+			"group": "Conception II - Children of the Seven Stars",
+			"titles": [
+				{"searchTerm": "Conception II - Children of the Seven Stars"},
+				{"searchTerm": "Conception II - Nanahoshi no Michibiki to Mazuru no Akumu"}
+			]
+		},	
+		{
+			"group": "Corridor Z",
+			"titles": [
+				{"searchTerm": "Corridor Z"},
+				{"searchTerm": "Corrizor Z"}
+			]
+		},		
+		{
+			"group": "Criminal Girls - Invite Only",
+			"titles": [
+				{"searchTerm": "Criminal Girls - Invite Only"},
+				{"searchTerm": "Criminal Girls - Invitation"}
+			]
+		},	
+		{
+			"group": "Criminal Girls 2 - Party Favors",
+			"titles": [
+				{"searchTerm": "Criminal Girls 2 - Party Favors"},
+				{"searchTerm": "Criminal Girls 2"}
+			]
+		},										
+		{
+			"group": "Danganronpa 2 - Goodbye Despair",
+			"titles": [
+				{"searchTerm": "Danganronpa 2 - Goodbye Despair"},
+				{"searchTerm": "Super Danganronpa 2"}
+			]
+		},
+		{
+			"group": "AeternoBlade",
+			"titles": [
+				{"searchTerm": "AeternoBlade"},
+				{"searchTerm": "Aeternoblade - Time Avenger"}
+			]
+		},
+		{
+			"group": "Akiba's Trip - Undead & Undressed",
+			"titles": [
+				{"searchTerm": "Akiba's Trip - Undead & Undressed"},
+				{"searchTerm": "Akiba's Trip 2"}
+			]
+		},
+		{
+			"group": "Balthazar's Dreams",
+			"titles": [
+				{"searchTerm": "Balthazar's Dreams"},
+				{"searchTerm": "Balthazar's Dream"}
+			]
+		},	
+		{
+			"group": "Berserk and the Band of the Hawk",
+			"titles": [
+				{"searchTerm": "Berserk and the Band of the Hawk"},
+				{"searchTerm": "Berserk Musou"}
+			]
+		},	
+		{
+			"group": "Best of Arcade Games",
+			"titles": [
+				{"searchTerm": "Best of Arcade Games"}
+			],
+			"supersets": [
+				{"searchTerm": "Best of Arcade Games - Deluxe Edition"}
+			]			
+		},		
+		{
+			"group": "Blast 'Em Bunnies",
+			"titles": [
+				{"searchTerm": "Blast 'Em Bunnies"},
+				{"searchTerm": "Blast 'Em Bunnies - Warui Usagi o Yattsukero!"}
+			]
+		},
+		{
+			"group": "BlazBlue - Chrono Phantasma Extend",
+			"titles": [
+				{"searchTerm": "BlazBlue - Chrono Phantasma Extend"},
+				{"searchTerm": "BlazBlue - Chronophantasma Extend"}
+			]
+		},			
+		{
+			"group": "BreakQuest - Extra Evolution",
+			"titles": [
+				{"searchTerm": "BreakQuest - Extra Evolution"}
+			],
+			"supersets": [
+				{"searchTerm": "BreakQuest - Extra Evolution Pro"}
+			]
+		},	
+		{
+			"group": "Call of Duty - Black Ops - Declassified",
+			"titles": [
+				{"searchTerm": "Call of Duty - Black Ops - Declassified"},
+				{"searchTerm": "Call of Duty - Black Ops Declassified"},
+				{"searchTerm": "Call of Duty Black Ops - Declassified"}
+			]
+		},		
+		{
+			"group": "Cursed Castilla EX",
+			"titles": [
+				{"searchTerm": "Cursed Castilla EX"},
+				{"searchTerm": "Cursed Castilla - Maldita Castilla EX"}
+			]
+		},	
+		{
+			"group": "Dairansou Dash or Dasshu!!",
+			"titles": [
+				{"searchTerm": "Dairansou Dash or Dasshu!! (Japan) (PCSG00395)", "nameType": "full"},
+				{"searchTerm": "Dairansou Dash or Dasshu!! (Japan) (PCSG00290)", "nameType": "full"}
+			]
+		},			
+		{
+			"group": "Damascus Gear - Operation Osaka",
+			"titles": [
+				{"searchTerm": "Damascus Gear - Operation Osaka"},
+				{"searchTerm": "Damascus Gear - Saikyou Exodus"}
+			]
+		},		
+		{
+			"group": "Damascus Gear - Operation Tokyo",
+			"titles": [
+				{"searchTerm": "Damascus Gear - Operation Tokyo"},
+				{"searchTerm": "Damascus Gear - Tokyo Shisen"}
+			]
+		},	
+		{
+			"group": "Danganronpa - Trigger Happy Havoc",
+			"titles": [
+				{"searchTerm": "Danganronpa - Trigger Happy Havoc"},
+				{"searchTerm": "Danganronpa"}
+			]
+		},	
+		{
+			"group": "Danganronpa 2 - Goodbye Despair",
+			"titles": [
+				{"searchTerm": "Danganronpa 2 - Goodbye Despair"},
+				{"searchTerm": "Super Danganronpa 2"}
+			]
+		},										
+		{
+			"group": "Danganronpa V3 - Killing Harmony",
+			"titles": [
+				{"searchTerm": "Danganronpa V3 - Killing Harmony (USA)", "nameType": "full"},
+				{"searchTerm": "New Danganronpa V3 - Minna no Koroshiai Shingakki (Japan)", "nameType": "full"}
+			]
+		},	
+		{
+			"group": "Danganronpa Another Episode - Ultra Despair Girls",
+			"titles": [
+				{"searchTerm": "Danganronpa Another Episode - Ultra Despair Girls"},
+				{"searchTerm": "Zettai Zetsubou Shoujo - Dangan-Ronpa - Another Episode (Asia) (Ja,Zh)", "nameType": "full"},
+				{"searchTerm": "Zettai Zetsubou Shoujo - Danganronpa - Another Episode (Japan) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},		
+		{
+			"group": "Darius Burst Chronicle Saviors",
+			"titles": [
+				{"searchTerm": "Darius Burst Chronicle Saviors"},
+				{"searchTerm": "Darius Burst Chronicle Saviours"}
+			]
+		},			
+		{
+			"group": "Dead or Alive Xtreme 3 - Venus",
+			"titles": [
+				{"searchTerm": "Dead or Alive Xtreme 3 - Venus"},
+				{"searchTerm": "Dead or Alive Xtreme 3 - Venus - Free-to-Play Version"},
+				{"searchTerm": "Dead or Alive Xtreme 3 - Venus - Kihon Muryouban"}
+			]
+		},
+		{
+			"group": "Deemo - The Last Recital",
+			"titles": [
+				{"searchTerm": "Deemo - The Last Recital"},
+				{"searchTerm": "Deemo - Last Recital"}
+			]
+		},		
+		{
+			"group": "Demon Gaze",
+			"titles": [
+				{"searchTerm": "Demon Gaze"}
+			],
+			"supersets": [
+				{"searchTerm": "Demon Gaze - Global Edition"}
+			]			
+		},	
+		{
+			"group": "Demon Gaze II",
+			"titles": [
+				{"searchTerm": "Demon Gaze II"}
+			],
+			"supersets": [
+				{"searchTerm": "Demon Gaze 2 Global Edition"}
+			]			
+		},		
+		{
+			"group": "Disgaea 3 - Absence of Detention",
+			"titles": [
+				{"searchTerm": "Disgaea 3 - Absence of Detention"},
+				{"searchTerm": "Makai Senki Disgaea 3 Return"}
+			]
+		},	
+		{
+			"group": "Disgaea 4 - A Promise Revisited",
+			"titles": [
+				{"searchTerm": "Disgaea 4 - A Promise Revisited"},
+				{"searchTerm": "Makai Senki Disgaea 4 Return"}
+			]
+		},	
+		{
+			"group": "Distraint - Deluxe Edition",
+			"titles": [
+				{"searchTerm": "Distraint - Deluxe Edition"},
+				{"searchTerm": "Dot Horror Story"}
+			]
+		},		
+		{
+			"group": "Divekick",
+			"titles": [
+				{"searchTerm": "Divekick"},
+				{"searchTerm": "Divekick - Addition Edition"}
+			]
+		},									
+		{
+			"group": "DJ Max Technika Tune",
+			"titles": [
+				{"searchTerm": "DJ Max Technika Tune"},
+				{"searchTerm": "DJMax Technika Tune"}
+			]
+		},	
+		{
+			"group": "Dragon's Crown",
+			"titles": [
+				{"searchTerm": "Dragon's Crown"},
+				{"searchTerm": "Dragon's Crown (Asia) (Zh,Ko) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},		
+		{
+			"group": "Dragon Fantasy Book I",
+			"titles": [
+				{"searchTerm": "Dragon Fantasy Book I"},
+				{"searchTerm": "Dragon Fantasy - The Volumes of Westeria"}
+			]
+		},		
+		{
+			"group": "Dragon Fantasy Book II",
+			"titles": [
+				{"searchTerm": "Dragon Fantasy Book II"},
+				{"searchTerm": "Dragon Fantasy - The Black Tome of Ice"}
+			]
+		},	
+		{
+			"group": "Dragon Quest Builders",
+			"titles": [
+				{"searchTerm": "Dragon Quest Builders"},
+				{"searchTerm": "Dragon Quest Builders - Alefgard o Fukkatsu Niseyo"}
+			]
+		},			
+		{
+			"group": "Dungeon Travelers 2 - The Royal Library & The Royal Seal",
+			"titles": [
+				{"searchTerm": "Dungeon Travelers 2 - The Royal Library & The Royal Seal"},
+				{"searchTerm": "Dungeon Travelers 2 - The Royal Library & The Monster Seal"},
+				{"searchTerm": "Dungeon Travelers 2 - Ouritsu Toshokan to Mamono no Fuuin"}
+			]
+		},	
+		{
+			"group": "Dynasty Warriors 8 - Empires",
+			"titles": [
+				{"searchTerm": "Dynasty Warriors 8 - Empires"},
+				{"searchTerm": "Dynasty Warriors 8 - Empires - Free Alliances Version"},
+				{"searchTerm": "Shin Sangoku Musou 7 - Empires"},
+				{"searchTerm": "Shin Sangoku Musou 7 Empires"},
+				{"searchTerm": "Shin Sangoku Musou 7 - Empires - Free Alliances Version"}
+			]
+		},	
+		{
+			"group": "Dynasty Warriors 8 - Xtreme Legends Complete Edition",
+			"titles": [
+				{"searchTerm": "Dynasty Warriors 8 - Xtreme Legends Complete Edition"},
+				{"searchTerm": "Shin Sangoku Musou 7 with Moushouden"}
+			]
+		},			
+		{
+			"group": "Dynasty Warriors Next",
+			"titles": [
+				{"searchTerm": "Dynasty Warriors Next"},
+				{"searchTerm": "Dynasty Warriors Next (Asia) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},	
+		{
+			"group": "Earth Defense Force 2 - Invaders from Planet Space",
+			"titles": [
+				{"searchTerm": "Earth Defense Force 2 - Invaders from Planet Space"},
+				{"searchTerm": "Chikyuu Boueigun 2 Portable V2 (Japan)", "nameType":"full"}
+			]
+		},	
+		{
+			"group": "Earth Defense Force 2017 Portable",
+			"titles": [
+				{"searchTerm": "Earth Defense Force 2017 Portable"},
+				{"searchTerm": "Chikyuu Boueigun 3 Portable"}
+			]
+		},	
+		{
+			"group": "EscapeVektor",
+			"titles": [
+				{"searchTerm": "EscapeVektor"},
+				{"searchTerm": "Dennou kara no Dasshutsu - EscapeVektor"}
+			]
+		},				
+		{
+			"group": "Everybody's Golf 6",
+			"titles": [
+				{"searchTerm": "Everybody's Golf 6"},
+				{"searchTerm": "Everybody's Golf"},
+				{"searchTerm": "Minna no Golf 6"}
+			]
+		},		
+		{
+			"group": "Farming Simulator 14",
+			"titles": [
+				{"searchTerm": "Farming Simulator 14"},
+				{"searchTerm": "Farming Simulator 14 - Pocket Nouen 2"}
+			]
+		},
+		{
+			"group": "Farming Simulator 16",
+			"titles": [
+				{"searchTerm": "Farming Simulator 16"},
+				{"searchTerm": "Farming Simulator 16 - Pocket Nouen 3"}
+			]
+		},
+		{
+			"group": "Farming Simulator 18",
+			"titles": [
+				{"searchTerm": "Farming Simulator 18"},
+				{"searchTerm": "Farming Simulator 18 - Pocket Nouen 4"}
+			]
+		},
+		{
+			"group": "Fate-Extella",
+			"titles": [
+				{"searchTerm": "Fate-Extella"},
+				{"searchTerm": "Fate-Extella - The Umbral Star"}
+			]
+		},		
+		{
+			"group": "Fort Defense North Menace",
+			"titles": [
+				{"searchTerm": "Fort Defense North Menace"},
+				{"searchTerm": "Fort Defense - North Menace"}
+			]
+		},
+		{
+			"group": "Gal Gun - Double Peace",
+			"titles": [
+				{"searchTerm": "Gal Gun - Double Peace"},
+				{"searchTerm": "Gal Gun - Double Peace - Bilingual"}
+			]
+		},
+		{
+			"group": "Ghoulboy",
+			"titles": [
+				{"searchTerm": "Ghoulboy"},
+				{"searchTerm": "Ghoulboy - Dark Sword of Goblin"}
+			]
+		},
+		{
+			"group": "God Eater 2 - Rage Burst",
+			"titles": [
+				{"searchTerm": "God Eater 2 - Rage Burst"},
+				{"searchTerm": "God Eater 2"}
+			]
+		},
+		{
+			"group": "God Wars - Future Past",
+			"titles": [
+				{"searchTerm": "God Wars - Future Past"},
+				{"searchTerm": "God Wars - Toki o Koete"}
+			]
+		},		
+		{
+			"group": "God Wars - The Complete Legend",
+			"titles": [
+				{"searchTerm": "God Wars - The Complete Legend"},
+				{"searchTerm": "God Wars - Nihon Shinwa Taisen"}
+			]
+		},		
+		{
+			"group": "Gravity Rush",
+			"titles": [
+				{"searchTerm": "Gravity Rush"},
+				{"searchTerm": "Gravity Daze"},
+				{"searchTerm": "Gravity Rush (Asia) (En,Zh,Ko) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},
+		{
+			"group": "Gundam Breaker 3 - Break Edition",
+			"titles": [
+				{"searchTerm": "Gundam Breaker 3 - Break Edition"},
+				{"searchTerm": "Gundam Breaker 3"}
+			]
+		},
+		{
+			"group": "Hakuoki - Kyoto Winds",
+			"titles": [
+				{"searchTerm": "Hakuoki - Kyoto Winds"},
+				{"searchTerm": "Hakuouki - Shinkai - Kaze no Shou"}
+			]
+		},
+		{
+			"group": "Hakuoki - Edo Blossoms",
+			"titles": [
+				{"searchTerm": "Hakuoki - Edo Blossoms"},
+				{"searchTerm": "Hakuouki - Shinkai - Hana no Shou"}
+			]
+		},
+		{
+			"group": "HD Adventures of Rotating Octopus Character",
+			"titles": [
+				{"searchTerm": "HD Adventures of Rotating Octopus Character"},
+				{"searchTerm": "HD Adventures of Rotating Octopus Character, The"}
+			]
+		},
+		{
+			"group": "House in Fata Morgana, The",
+			"titles": [
+				{"searchTerm": "House in Fata Morgana, The"},
+				{"searchTerm": "Fata Morgana no Kan - Collected Edition"}
+			]
+		},		
+		{
+			"group": "Hyperdimension Neptunia U - Action Unleashed",
+			"titles": [
+				{"searchTerm": "Hyperdimension Neptunia U - Action Unleashed"},
+				{"searchTerm": "Chou Jigen Action - Neptune U"}
+			]
+		},
+		{
+			"group": "Hyperdevotion Noire - Goddess Black Heart",
+			"titles": [
+				{"searchTerm": "Hyperdevotion Noire - Goddess Black Heart"},
+				{"searchTerm": "Chou Megami Shinkou Noire - Gekishin Black Heart"}
+			]
+		},
+		{
+			"group": "Hyperdimension Neptunia Re;Birth2 - Sisters Generation",
+			"titles": [
+				{"searchTerm": "Hyperdimension Neptunia Re;Birth2 - Sisters Generation"},
+				{"searchTerm": "Chou Tsugitsugimono Game Neptune Re;Birth2 - Sisters Generation"}
+			]
+		},						
+		{
+			"group": "Injustice - Gods Among Us - Ultimate Edition",
+			"titles": [
+				{"searchTerm": "Injustice - Gods Among Us - Ultimate Edition"},
+				{"searchTerm": "Injustice - Kamigami no Gekitotsu"}
+			]
+		},
+		{
+			"group": "Injustice - Gods Among Us - Ultimate Edition",
+			"titles": [
+				{"searchTerm": "Injustice - Gods Among Us - Ultimate Edition"},
+				{"searchTerm": "Injustice - Kamigami no Gekitotsu"}
+			]
+		},
+		{
+			"group": "Invizimals - Hidden Challenges",
+			"titles": [
+				{"searchTerm": "Invizimals - Hidden Challenges"},
+				{"searchTerm": "Invizimals - Collectible Card Game - Hidden Challenges"}
+			]
+		},	
+		{
+			"group": "Jak and Daxter Collection",
+			"titles": [
+				{"searchTerm": "Jak and Daxter Collection"},
+				{"searchTerm": "Jak and Daxter Trilogy, The"}
+			]
+		},				
+		{
+			"group": "Jetpack Joyride",
+			"titles": [
+				{"searchTerm": "Jetpack Joyride"}
+			],
+			"supersets": [
+				{"searchTerm": "Jetpack Joyride Deluxe"}
+			]
+		},
+		{
+			"group": "Killzone - Mercenary",
+			"titles": [
+				{"searchTerm": "Killzone - Mercenary"},
+				{"searchTerm": "Kilzone - Mercenary"}
+			]
+		},
+		{
+			"group": "Knock-Knock",
+			"titles": [
+				{"searchTerm": "Knock-Knock"},
+				{"searchTerm": "Knock Knock"}
+			]
+		},
+		{
+			"group": "Last Blade 2, The",
+			"titles": [
+				{"searchTerm": "Last Blade 2, The"},
+				{"searchTerm": "Bakumatsu Roman Daini Tobari - Gekka no Kenshi"}
+			]
+		},		
+		{
+			"group": "Legend of Heroes, The - Trails of Cold Steel",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Trails of Cold Steel"},
+				{"searchTerm": "Legend of Heroes, The - Sen no Kiseki"}
+			]
+		},
+		{
+			"group": "Legend of Heroes, The - Trails of Cold Steel II",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Trails of Cold Steel II"},
+				{"searchTerm": "Legend of Heroes, The - Sen no Kiseki II"}
+			]
+		},
+		{
+			"group": "Legend of Heroes, The - Trails of Cold Steel II",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Trails of Cold Steel II"},
+				{"searchTerm": "Legend of Heroes, The - Sen no Kiseki II"}
+			]
+		},
+		{
+			"group": "Legend of Heroes, The - Sora no Kiseki FC Evolution",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Sora no Kiseki FC Evolution"},
+				{"searchTerm": "Eiyuu Densetsu - Sora no Kiseki FC Evolution"},
+				{"searchTerm": "Yingxiong Chuanshuo - Kong Zhi Guiji Di-Yi Zhang Quanmian Jinhuaban"}
+			]
+		},	
+		{
+			"group": "Legend of Heroes, The - Sora No Kiseki SC Evolution",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Sora No Kiseki SC Evolution"},
+				{"searchTerm": "Eiyuu Densetsu - Sora no Kiseki SC Evolution"}
+			]
+		},	
+		{
+			"group": "Legend of Heroes, The - Sora No Kiseki the 3rd Evolution",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Sora No Kiseki the 3rd Evolution"},
+				{"searchTerm": "Eiyuu Densetsu - Sora no Kiseki the 3rd Evolution"}
+			]
+		},
+		{
+			"group": "Legend of Heroes, The - Zero no Kiseki Evolution",
+			"titles": [
+				{"searchTerm": "Legend of Heroes, The - Zero no Kiseki Evolution"},
+				{"searchTerm": "Eiyuu Densetsu - Zero no Kiseki Evolution"}
+			]
+		},							
+		{
+			"group": "Longest Five Minutes, The",
+			"titles": [
+				{"searchTerm": "Longest Five Minutes, The"},
+				{"searchTerm": "Sekai Ichi Nagai 5-fun Kan"}
+			]
+		},		
+		{
+			"group": "Magical Beat",
+			"titles": [
+				{"searchTerm": "Magical Beat"},
+				{"searchTerm": "Magical Beat - Beat de Tsunaku Ochimo no Puzzle"}
+			]
+		},		
+		{
+			"group": "Mahou Shoujo Taisen Zanbatsu",
+			"titles": [
+				{"searchTerm": "Mahou Shoujo Taisen Zanbatsu (Japan) (PCSG00392)", "nameType": "full"},
+				{"searchTerm": "Mahou Shoujo Taisen Zanbatsu (Japan) (PCSG00368)", "nameType": "full"}
+			]
+		},		
+		{
+			"group": "MegaTagmension Blanc + Neptune vs. Zombies",
+			"titles": [
+				{"searchTerm": "MegaTagmension Blanc + Neptune vs. Zombies"},
+				{"searchTerm": "MegaTagmension Blanc + Neptune VS Zombies"}
+			]
+		},
+		{
+			"group": "Metal Gear Solid 2 - Sons of Liberty - HD Edition",
+			"titles": [
+				{"searchTerm": "Metal Gear Solid 2 - Sons of Liberty - HD Edition"},
+				{"searchTerm": "Metal Gear Solid 2 HD Edition"}
+			]
+		},
+		{
+			"group": "Metal Gear Solid 3 - Snake Eater HD Edition",
+			"titles": [
+				{"searchTerm": "Metal Gear Solid 3 - Snake Eater HD Edition"},
+				{"searchTerm": "Metal Gear Solid 3 HD Edition"}
+			]
+		},
+		{
+			"group": "Metal Gear Solid HD Collection",
+			"titles": [
+				{"searchTerm": "Metal Gear Solid HD Collection"},
+				{"searchTerm": "Metal Gear Solid HD Collection (Japan) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},
+		{
+			"group": "MotorStorm RC",
+			"titles": [
+				{"searchTerm": "MotorStorm RC - Presented by Scion"}
+			],
+			"supersets": [
+				{"searchTerm": "MotorStorm RC"}
+			] 
+		},
+		{
+			"group": "Mr. Pumpkin's Adventure",
+			"titles": [
+				{"searchTerm": "Mr. Pumpkin's Adventure"},
+				{"searchTerm": "Mr. Pumpkin Adventure"},
+				{"searchTerm": "Mr. Pumpkin no Fushigi na Tabi"}
+			]
+		},
+		{
+			"group": "Musynx",
+			"titles": [
+				{"searchTerm": "Musynx"},
+				{"searchTerm": "Musync"}
+			]
+		},
+		{
+			"group": "Mystery Chronicle - One Way Heroics",
+			"titles": [
+				{"searchTerm": "Mystery Chronicle - One Way Heroics"},
+				{"searchTerm": "Mystery Chronicle - One Way Heroes"},
+				{"searchTerm": "Fushigi no Chronicle - Furikaerimasen Katsu Madewa" }
+			]
+		},
+		{
+			"group": "Necrosphere",
+			"titles": [
+				{"searchTerm": "Necrosphere"}
+			],
+			"supersets": [
+				{"searchTerm": "Necrosphere Deluxe"}
+			] 
+		},
+		{
+			"group": "New Game! The Challenge Stage!",
+			"titles": [
+				{"searchTerm": "New Game! The Challenge Stage!"},
+				{"searchTerm": "New Game! - The Challenge Stage!"}
+			]
+		},
+		{
+			"group": "Nihilumbra",
+			"titles": [
+				{"searchTerm": "Nihilumbra"},
+				{"searchTerm": "Nihilumbra - Seimei to Shikisai no Tabiji"}
+			]
+		},
+		{
+			"group": "No Heroes Allowed - No Puzzles Either!",
+			"titles": [
+				{"searchTerm": "No Heroes Allowed - No Puzzles Either!"},
+				{"searchTerm": "Yuusha no Kuse ni Konamaikida. G"}
+			]
+		},		
+		{
+			"group": "Nobunaga's Ambition - Souzou",
+			"titles": [
+				{"searchTerm": "Nobunaga's Ambition - Souzou"},
+				{"searchTerm": "Nobunaga no Yabou - Souzou"}
+			]
+		},		
+		{
+			"group": "Nobunaga's Ambition - Souzou - Sengoku Risshiden",
+			"titles": [
+				{"searchTerm": "Nobunaga's Ambition - Souzou - Sengoku Risshiden"},
+				{"searchTerm": "Nobunaga no Yabou - Souzou Sengoku Risshiden"}
+			]
+		},		
+		{
+			"group": "Nobunaga's Ambition - Sphere of Influence",
+			"titles": [
+				{"searchTerm": "Nobunaga's Ambition - Sphere of Influence"},
+				{"searchTerm": "Nobunaga no Yabou - Souzou with Power-Up Kit"}
+			]
+		},
+		{
+			"group": "Octodad - Dadliest Catch",
+			"titles": [
+				{"searchTerm": "Octodad - Dadliest Catch"},
+				{"searchTerm": "Octodad - Tako to Yoba na Ide"}
+			]
+		},
+		{
+			"group": "Odin Sphere - Leifdrasir",
+			"titles": [
+				{"searchTerm": "Odin Sphere - Leifdrasir"},
+				{"searchTerm": "Odin Sphere - Leifthrasir"}
+			]
+		},
+		{
+			"group": "OlliOlli",
+			"titles": [
+				{"searchTerm": "OlliOlli"}
+			]
+		},
+		{
+			"group": "One Piece Unlimited World Red",
+			"titles": [
+				{"searchTerm": "One Piece Unlimited World Red"},
+				{"searchTerm": "One Piece - Unlimited World Red"},
+				{"searchTerm": "One Piece - Unlimited World R"}
+			]
+		},
+		{
+			"group": "Open Me!",
+			"titles": [
+				{"searchTerm": "Open Me!"},
+				{"searchTerm": "Hako! Open Me"},
+				{"searchTerm": "Open Me! Digest Ver."},
+				{"searchTerm": "Hako! Open Me - Digest Version"}
+			]
+		},
+		{
+			"group": "Oreshika - Tainted Bloodlines",
+			"titles": [
+				{"searchTerm": "Oreshika - Tainted Bloodlines"},
+				{"searchTerm": "Ore no Shikabane o Koete Yuke 2"}
+			]
+		},
+		{
+			"group": "Paint Park Plus",
+			"titles": [
+				{"searchTerm": "Paint Park Plus"},
+				{"searchTerm": "E Channel - New Paint Park"}
+			]
+		},		
+		{
+			"group": "Perils of Baking - Refrosted",
+			"titles": [
+				{"searchTerm": "Perils of Baking - Refrosted"},
+				{"searchTerm": "Perils of Baking"}
+			]
+		},
+		{
+			"group": "Persona 3 - Dancing in Moonlight",
+			"titles": [
+				{"searchTerm": "Persona 3 - Dancing in Moonlight"},
+				{"searchTerm": "Persona 3 - Dancing Moon Night"}
+			]
+		},
+		{
+			"group": "Persona 4 Golden",
+			"titles": [
+				{"searchTerm": "Persona 4 Golden"},
+				{"searchTerm": "Persona 4 - The Golden (Japan) (PlayStation Vita the Best)", "nameType":"full"}
+			]
+		},
+		{
+			"group": "Persona 5 - Dancing in Starlight",
+			"titles": [
+				{"searchTerm": "Persona 5 - Dancing in Starlight"},
+				{"searchTerm": "Persona 5 - Dancing Star Night"}
+			]
+		},
+		{
+			"group": "Phineas and Ferb - Day of Doofenshmirtz",
+			"titles": [
+				{"searchTerm": "Phineas and Ferb - Day of Doofenshmirtz"},
+				{"searchTerm": "Phineas and Ferb - Day of Doofenshimirtz"}
+			]
+		},
+		{
+			"group": "PixelJunk Monsters Ultimate HD",
+			"titles": [
+				{"searchTerm": "PixelJunk Monsters Ultimate HD"},
+				{"searchTerm": "PixelJunk Monsters - Ultimate HD"}
+			]
+		},
+		{
+			"group": "Psychedelica of the Ashen Hawk",
+			"titles": [
+				{"searchTerm": "Psychedelica of the Ashen Hawk"},
+				{"searchTerm": "Psychedelica of Gray Hawk"}
+			]
+		},
+		{
+			"group": "Psycho-Pass - Mandatory Happiness",
+			"titles": [
+				{"searchTerm": "Psycho-Pass - Mandatory Happiness"},
+				{"searchTerm": "Psycho-Pass - Sentaku Naki Koufuku"}
+			]
+		},
+		{
+			"group": "PulzAR",
+			"titles": [
+				{"searchTerm": "PulzAR"},
+				{"searchTerm": "Puls-AR"}
+			]
+		},
+		{
+			"group": "Puzzle by Nikoli V - Slitherlink",
+			"titles": [
+				{"searchTerm": "Puzzle by Nikoli V - Slitherlink"},
+				{"searchTerm": "Nikoli no Puzzle V - Slitherlink"}
+			]
+		},
+		{
+			"group": "Puzzle by Nikoli V - Sudoku",
+			"titles": [
+				{"searchTerm": "Puzzle by Nikoli V - Sudoku"},
+				{"searchTerm": "Nikoli no Puzzle V - Sudoku"}
+			]
+		},
+		{
+			"group": "Puzzle by Nikoli V - Sudoku",
+			"titles": [
+				{"searchTerm": "Puzzle by Nikoli V - Sudoku"},
+				{"searchTerm": "Nikoli no Puzzle V - Sudoku"}
+			]
+		},
+		{
+			"group": "Ragnarok Odyssey",
+			"titles": [
+				{"searchTerm": "Ragnarok Odyssey"},
+				{"searchTerm": "Ragnarok Odyssey (Asia) (En,Zh,Ko) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},	
+		{
+			"group": "Ragnarok Odyssey Ace",
+			"titles": [
+				{"searchTerm": "Ragnarok Odyssey Ace"},
+				{"searchTerm": "Ragnarok Odyssey Ace (Asia) (En,Zh,Ko) (PlayStation Vita the Best)", "nameType": "full"},
+				{"searchTerm": "Ragnarok Odyssey Ace (Asia) (En,Zh,Ko) (Trial)", "nameType": "full"}
+			]
+		},			
+		{
+			"group": "Ratchet & Clank - Full Frontal Assault",
+			"titles": [
+				{"searchTerm": "Ratchet & Clank - Full Frontal Assault"},
+				{"searchTerm": "Ratchet & Clank - QForce"},
+				{"searchTerm": "Ratchet & Clank - Ginga Sentai QForce"}
+			]
+		},
+		{
+			"group": "Ratchet & Clank Collection",
+			"titles": [
+				{"searchTerm": "Ratchet & Clank Collection"},
+				{"searchTerm": "Ratchet & Clank Trilogy"}
+			]
+		},
+		{
+			"group": "Reel Fishing - Master's Challenge",
+			"titles": [
+				{"searchTerm": "Reel Fishing - Master's Challenge"},
+				{"searchTerm": "Reel Fishing - Wasureteita Yakusoku"}
+			]
+		},
+		{
+			"group": "Resident Evil - Revelations 2",
+			"titles": [
+				{"searchTerm": "Resident Evil - Revelations 2"},
+				{"searchTerm": "Biohazard - Revelations 2"}
+			]
+		},		
+		{
+			"group": "Retro City Rampage",
+			"titles": [
+				{"searchTerm": "Retro City Rampage"}
+			],
+			"supersets": [
+				{"searchTerm": "Retro City Rampage DX"}
+			]
+		},
+		{
+			"group": "Romance of the Three Kingdoms XIII - Fame and Strategy Expansion Pack Bundle",
+			"titles": [
+				{"searchTerm": "Romance of the Three Kingdoms XIII - Fame and Strategy Expansion Pack Bundle"},
+				{"searchTerm": "San Goku Shi 13 with Power-Up Kit"}
+			]
+		},
+		{
+			"group": "Rose in the Twilight, A",
+			"titles": [
+				{"searchTerm": "Rose in the Twilight, A"},
+				{"searchTerm": "Rose to Tasogare no Kojo"},
+				{"searchTerm": "Rose to Tasogare no Kojou"}
+			]
+		},
+		{
+			"group": "Samurai Warriors Chronicles 3",
+			"titles": [
+				{"searchTerm": "Samurai Warriors Chronicles 3"},
+				{"searchTerm": "Samurai Warriors - Chronicles 3"},
+				{"searchTerm": "Sengoku Musou Chronicle 3"}
+			]
+		},			
+		{
+			"group": "Samurai Warriors 4 Empires",
+			"titles": [
+				{"searchTerm": "Samurai Warriors 4 Empires"},
+				{"searchTerm": "Sengoku Musou 4 Empires"}
+			]
+		},			
+		{
+			"group": "Samurai Warriors 4-II",
+			"titles": [
+				{"searchTerm": "Samurai Warriors 4-II"},
+				{"searchTerm": "Sengoku Musou 4-II"}
+			]
+		},		
+		{
+			"group": "Sayonara UmiharaKawase +",
+			"titles": [
+				{"searchTerm": "Sayonara UmiharaKawase +"},
+				{"searchTerm": "Sayonara Umihara Kawase Chirari"}
+			]
+		},
+		{
+			"group": "Secret of Mana",
+			"titles": [
+				{"searchTerm": "Secret of Mana"},
+				{"searchTerm": "Seiken Densetsu 2 - Secret of Mana"}
+			]
+		},
+		{
+			"group": "Senran Kagura - Estival Versus",
+			"titles": [
+				{"searchTerm": "Senran Kagura - Estival Versus"},
+				{"searchTerm": "Senran Kagura - Estival Versus - Shoujotachi no Sentaku"}
+			]
+		},		
+		{
+			"group": "Senran Kagura Bon Appetit!",
+			"titles": [
+				{"searchTerm": "Senran Kagura Bon Appetit!"},
+				{"searchTerm": "Dekamori Senran Kagura - Body Pack A - Hanzo & Guren"},
+				{"searchTerm": "Dekamori Senran Kagura - Hontai Pack A - Hanzo & Guren"},
+				{"searchTerm": "Dekamori Senran Kagura - Body Pack B"},
+				{"searchTerm": "Dekamori Senran Kagura - Hontai Pack B"}				
+			]
+		},		
+		{
+			"group": "Senran Kagura Shinovi Versus",
+			"titles": [
+				{"searchTerm": "Senran Kagura Shinovi Versus"},
+				{"searchTerm": "Senran Kagura Shinovi Versus - Shoujotachi no Shoumei"}
+			]
+		},		
+		{
+			"group": "Shiren the Wanderer",
+			"titles": [
+				{"searchTerm": "Shiren the Wanderer"},
+				{"searchTerm": "Shiren the Wanderer - The Tower of Fortune and the Dice of Fate"}
+			]
+		},
+		{
+			"group": "Sid Meier's Civilization Revolution 2 Plus",
+			"titles": [
+				{"searchTerm": "Sid Meier's Civilization Revolution 2 Plus"},
+				{"searchTerm": "Sid Meier's Civilization Revolution 2+"}
+			]
+		},
+		{
+			"group": "Skullgirls 2nd Encore",
+			"titles": [
+				{"searchTerm": "Skullgirls 2nd Encore"},
+				{"searchTerm": "Skullgirls - 2nd Encore"}
+			]
+		},	
+		{
+			"group": "Sly 3 - Honor Among Thieves",
+			"titles": [
+				{"searchTerm": "Sly 3 - Honor Among Thieves"},
+				{"searchTerm": "Sly 3 - Honour Among Thieves"}
+			]
+		},		
+		{
+			"group": "Sorcery Saga - Curse of the Great Curry God",
+			"titles": [
+				{"searchTerm": "Sorcery Saga - Curse of the Great Curry God"},
+				{"searchTerm": "Sei Madou Monogatari"}
+			]
+		},
+		{
+			"group": "Squareboy vs. Bullies - Arena Edition",
+			"titles": [
+				{"searchTerm": "Squareboy vs. Bullies - Arena Edition"},
+				{"searchTerm": "Squareboy vs Bullies - Arena Edition"}
+			]
+		},	
+		{
+			"group": "Stealth Inc. - A Clone in the Dark",
+			"titles": [
+				{"searchTerm": "Stealth Inc. - A Clone in the Dark"},
+				{"searchTerm": "Stealth Inc. - A Clone in the Dark - Ultimate Edition"}
+			]
+		},					
+		{
+			"group": "Summon Night 6 - Lost Borders",
+			"titles": [
+				{"searchTerm": "Summon Night 6 - Lost Borders"},
+				{"searchTerm": "Summon Night 6 - Ushinawareta Kyoukaitachi"}
+			]
+		},
+		{
+			"group": "Superdimension Neptune vs. Sega Hard Girls",
+			"titles": [
+				{"searchTerm": "Superdimension Neptune vs. Sega Hard Girls"},
+				{"searchTerm": "Superdimension Neptune VS Sega Hard Girls"},
+				{"searchTerm": "Chou Jigen Taisen Neptune VS Sega Hard Girls - Yume no Gattai Special"}
+			]
+		},		
+		{
+			"group": "Super Destronaut DX",
+			"titles": [
+				{"searchTerm": "Super Destronaut DX"}
+			],
+			"supersets": [
+				{"searchTerm": "Super Destronaut DX - Intruders Edition"}
+			]
+		},
+		{
+			"group": "Super Exploding Zoo",
+			"titles": [
+				{"searchTerm": "Super Exploding Zoo"},
+				{"searchTerm": "Super Exploding Zoo!"}
+			]
+		},
+		{
+			"group": "Super Monkey Ball - Banana Splitz",
+			"titles": [
+				{"searchTerm": "Super Monkey Ball - Banana Splitz"},
+				{"searchTerm": "Super Monkey Ball - Tokumori AsoVita!"}
+			]
+		},
+		{
+			"group": "Super Robot Wars V",
+			"titles": [
+				{"searchTerm": "Super Robot Wars V"},
+				{"searchTerm": "Super Robot Taisen V"}				
+			],
+			"supersets": [
+				{"searchTerm": "Super Robot Taisen V - Premium Anime Song & Sound Edition"}
+			]
+		},
+		{
+			"group": "Super Robot Wars X",
+			"titles": [
+				{"searchTerm": "Super Robot Wars X"},
+				{"searchTerm": "Super Robot Taisen X"}
+			],
+			"supersets": [
+				{"searchTerm": "Super Robot Taisen X - Premium Anime & Sound Edition"}
+			]
+		},
+		{
+			"group": "Superdimension Neptune vs. Sega Hard Girls",
+			"titles": [
+				{"searchTerm": "Superdimension Neptune vs. Sega Hard Girls"},
+				{"searchTerm": "Superdimension Neptune VS Sega Hard Girls"}
+			]
+		},
+		{
+			"group": "Superdimension Neptune vs. Sega Hard Girls",
+			"titles": [
+				{"searchTerm": "Superdimension Neptune vs. Sega Hard Girls"},
+				{"searchTerm": "Superdimension Neptune VS Sega Hard Girls"}
+			]
+		},
+		{
+			"group": "Sword Art Online - Lost Song",
+			"titles": [
+				{"searchTerm": "Sword Art Online - Lost Song"},
+				{"searchTerm": "Sword Art Online - Lost Song (Asia) (PCSH00134)", "nameType": "full"}
+			]
+		},		
+		{
+			"group": "Table Ice Hockey",
+			"titles": [
+				{"searchTerm": "Table Ice Hockey"},
+				{"searchTerm": "Table Play Ice Hockey"}
+			]
+		},		
+		{
+			"group": "Table Mini Golf",
+			"titles": [
+				{"searchTerm": "Table Mini Golf"},
+				{"searchTerm": "Table Play Golf"}
+			]
+		},
+		{
+			"group": "Table Soccer",
+			"titles": [
+				{"searchTerm": "Table Soccer"},
+				{"searchTerm": "Table Football"},
+				{"searchTerm": "Table Play Soccer"}
+			]
+		},
+		{
+			"group": "Tearaway",
+			"titles": [
+				{"searchTerm": "Tearaway (USA) (Trial)", "nameType": "full"},
+				{"searchTerm": "Tearaway - Hagareta Sekai no Daibouken (Japan) (Trial)", "nameType":"full"}
+			]
+		},		
+		{
+			"group": "Tiny Troopers - Joint Ops",
+			"titles": [
+				{"searchTerm": "Tiny Troopers - Joint Ops"},
+				{"searchTerm": "Tiny Troopers Joint Ops"}
+			]
+		},
+		{
+			"group": "Toro's Friend Network",
+			"titles": [
+				{"searchTerm": "Toro's Friend Network"},
+				{"searchTerm": "Toro's Friendly Network"},
+				{"searchTerm": "Toro's Friends Network"}
+			]
+		},
+		{
+			"group": "Touhou Kobuto V - Burst Battle",
+			"titles": [
+				{"searchTerm": "Touhou Kobuto V - Burst Battle"},
+				{"searchTerm": "Touhou Koubutou V"}
+			]
+		},	
+		{
+			"group": "Toukiden 2 - Free Alliances Version",
+			"titles": [
+				{"searchTerm": "Toukiden 2 - Free Alliances Version"},
+				{"searchTerm": "Toukiden 2 - Free Alliances Version - Co-Op Battle Version"}
+			]
+		},	
+		{
+			"group": "Toukiden - The Age of Demons",
+			"titles": [
+				{"searchTerm": "Toukiden - The Age of Demons"},
+				{"searchTerm": "Toukiden (Asia) (PlayStation Vita the Best)", "nameType": "full"},
+				{"searchTerm": "Toukiden"}
+			]
+		},				
+		{
+			"group": "Trillion - God of Destruction",
+			"titles": [
+				{"searchTerm": "Trillion - God of Destruction"},
+				{"searchTerm": "Makaishin Trillion"},
+				{"searchTerm": "Makaigami Trillion" }
+			]
+		},
+		{
+			"group": "Uncharted - Golden Abyss",
+			"titles": [
+				{"searchTerm": "Uncharted - Golden Abyss"},
+				{"searchTerm": "Uncharted - Chizu Naki Bouken no Hajimari"}
+			]
+		},
+		{
+			"group": "Utawarerumono - Mask of Deception",
+			"titles": [
+				{"searchTerm": "Utawarerumono - Mask of Deception"},
+				{"searchTerm": "Utawarerumono - Itsuwari no Kamen"}
+			]
+		},
+		{
+			"group": "Utawarerumono - Mask of Truth",
+			"titles": [
+				{"searchTerm": "Utawarerumono - Mask of Truth"},
+				{"searchTerm": "Utawarerumono - Futari no Hakuoro"}
+			]
+		},		
+		{
+			"group": "Utawarerumono - Prelude to the Fallen",
+			"titles": [
+				{"searchTerm": "Utawarerumono - Prelude to the Fallen"},
+				{"searchTerm": "Utawarerumono - Chiriyukusha e no Komoriuta"}
+			]
+		},	
+		{
+			"group": "Valhalla Knights 3",
+			"titles": [
+				{"searchTerm": "Valhalla Knights 3"}
+			],
+			"supersets": [
+				{"searchTerm": "Valhalla Knights 3 Gold"}
+			]
+		},		
+		{
+			"group": "Valkyria Revolution",
+			"titles": [
+				{"searchTerm": "Valkyria Revolution"},
+				{"searchTerm": "Valkyria - Azure Revolution"}
+			]
+		},		
+		{
+			"group": "Velocity 2X",
+			"titles": [
+				{"searchTerm": "Velocity 2X"}
+			],
+			"supersets": [
+				{"searchTerm": "Velocity 2X - Critical Mass Edition"}
+			]
+		},	
+		{
+			"group": "XBlaze - Lost Memories",
+			"titles": [
+				{"searchTerm": "XBlaze - Lost Memories"},
+				{"searchTerm": "XBlaze Lost - Memories"}
+			]
+		},	
+		{
+			"group": "Ys - Memories of Celceta",
+			"titles": [
+				{"searchTerm": "Ys - Memories of Celceta"},
+				{"searchTerm": "Ys - The Foliage Ocean in Celceta"},
+				{"searchTerm": "Ys - Celceta no Jukai (Japan) (PlayStation Vita the Best)", "nameType": "full"}
+			]
+		},	
+		{
+			"group": "Zero Escape - The Nonary Games",
+			"titles": [
+				{"searchTerm": "Zero Escape - The Nonary Games"},
+				{"searchTerm": "Zero Escape - 9 Jikan 9 nin 9 no Tobira Zennin Shibo Dos Double Pack"}
+			]
+		},	
+		{
+			"group": "Zero Escape - Zero Time Dilemma",
+			"titles": [
+				{"searchTerm": "Zero Escape - Zero Time Dilemma"},
+				{"searchTerm": "Zero Escape - Toki no Dilemma"}
+			]
+		},		
+		{
+			"group": "Zombie Tycoon II - Brainhov's Revenge",
+			"titles": [
+				{"searchTerm": "Zombie Tycoon II - Brainhov's Revenge"},
+				{"searchTerm": "Zombie Tycoon 2 - Brainhov's Revenge"}
+			]
+		}							
+	]
+}


### PR DESCRIPTION
Created `Nintendo - Wii U (Redump).json` that removes clonelist for mostly Japanese games. It is matched against NO-INTRO DAT `Nintendo - Wii U - WUX (513) (2023-04-30).dat`, which includeds `.wux` roms.

Created `Sony - PlayStation Vita (PSN) (Content) (No-Intro).json` that removes a lot of variants for the same titles. It is matched against NO-INTRO DAT `Sony - PlayStation Vita (PSN) (Content) (20220715-104102).dat`

The variants for the game titles is mostly sourced from https://renascene.com/psv/ and https://ogdb.eu/, which saves me tons of time having to google or read through wikipedia references.