### PR TITLE
Make "IQ 180 (USA)" a clone of "I.Q. 180 (USA)"

### DIFF
--- a/clonelists/Atari - 2600 (No-Intro).json
+++ b/clonelists/Atari - 2600 (No-Intro).json
@@ -1,7 +1,7 @@
 {
 	"description": {
 		"name": "Atari - 2600 (No-Intro)",
-		"lastUpdated": "10 February 2023",
+		"lastUpdated": "09 March 2023",
 		"minimumVersion": "2.02"
 	},
 
@@ -146,7 +146,9 @@
 			"group": "Forest",
 			"titles": [
 				{"searchTerm": "Forest (Two Player)"},
-				{"searchTerm": "Forest (One Player)", "priority": 2}
+				{"searchTerm": "Forest (Two Player) (Muted)", "priority": 2},
+				{"searchTerm": "Forest (One Player)", "priority": 3},
+				{"searchTerm": "Forest (One Player) (Muted)", "priority": 4}
 			]
 		},
 		{
@@ -178,7 +180,7 @@
 			]
 		},
 		{
-			"group": "I.Q. 180",
+			"group": "IQ 180",
 			"titles": [
 				{"searchTerm": "IQ 180"},
 				{"searchTerm": "I.Q. Memory Teaser"},
@@ -204,6 +206,13 @@
 			"titles": [
 				{"searchTerm": "Laaser Voley"},
 				{"searchTerm": "Laser Gates"}
+			]
+		},
+		{
+			"group": "Maze Craze - A Game of Cops 'n Robbers ~ Maze Mania - A Game of Cops 'n Robbers",
+			"titles": [
+				{"searchTerm": "Labyrinth"},
+				{"searchTerm": "Maze Craze - A Game of Cops 'n Robbers ~ Maze Mania - A Game of Cops 'n Robbers"}
 			]
 		},
 		{
@@ -261,6 +270,7 @@
 		{
 			"group": "Sea Hawk",
 			"titles": [
+				{"searchTerm": "Marineflieger"},
 				{"searchTerm": "Sea Hawk"},
 				{"searchTerm": "Seahawk"}
 			]

--- a/clonelists/Atari - 2600 (No-Intro).json
+++ b/clonelists/Atari - 2600 (No-Intro).json
@@ -180,9 +180,9 @@
 		{
 			"group": "I.Q. 180",
 			"titles": [
-				{"searchTerm": "I.Q. 180"},
+				{"searchTerm": "IQ 180"},
 				{"searchTerm": "I.Q. Memory Teaser"},
-				{"searchTerm": "IQ 180"}
+				{"searchTerm": "I.Q. 180", "priority": 2}
 			]
 		},
 		{

--- a/clonelists/Atari - 2600 (No-Intro).json
+++ b/clonelists/Atari - 2600 (No-Intro).json
@@ -181,7 +181,8 @@
 			"group": "I.Q. 180",
 			"titles": [
 				{"searchTerm": "I.Q. 180"},
-				{"searchTerm": "I.Q. Memory Teaser"}
+				{"searchTerm": "I.Q. Memory Teaser"},
+				{"searchTerm": "IQ 180"}
 			]
 		},
 		{


### PR DESCRIPTION
It's clear [I.Q. 180 (USA)](https://datomatic.no-intro.org/index.php?page=show_record&s=88&n=0209) and [I.Q. Memory Teaser (Europe)](https://datomatic.no-intro.org/index.php?page=show_record&s=88&n=0210) are the same, but it seems we're missing [IQ 180 (USA)](https://datomatic.no-intro.org/index.php?page=show_record&s=88&n=0573) in the mix!