### PR TITLE
Update Sony - PlayStation 2 (Redump).json

### DIFF
--- a/clonelists/Sony - PlayStation 2 (Redump).json
+++ b/clonelists/Sony - PlayStation 2 (Redump).json
@@ -851,6 +851,13 @@
 			]
 		},
 		{
+			"group": "Centre Court - Hard Hitter",
+			"titles": [
+				{"searchTerm": "Centre Court - Hard Hitter"},
+				{"searchTerm": "Hard Hitter"}
+			]
+		},
+		{
 			"group": "Champions of Norrath",
 			"titles": [
 				{"searchTerm": "Champions of Norrath"},
@@ -877,6 +884,13 @@
 			"titles": [
 				{"searchTerm": "Check-i-TV (Kyou kara Check! Pack)"},
 				{"searchTerm": "Check-i-TV", "priority": 2}
+			]
+		},
+		{
+			"group": "Choro Q",
+			"titles": [
+				{"searchTerm": "Choro Q"},
+				{"searchTerm": "Choro Q HG 4"}
 			]
 		},
 		{
@@ -1533,10 +1547,10 @@
 			]
 		},
 		{
-			"group": "Dot Hack Fraegment (Senkou Release-ban)",
+			"group": "Dot Hack Fraegment",
 			"titles": [
-				{"searchTerm": "Dot Hack Fraegment (Senkou Release-ban)"},
-				{"searchTerm": "Dot Hack Fraegment", "priority": 2}
+				{"searchTerm": "Dot Hack Fraegment"},
+				{"searchTerm": "Dot Hack Fraegment (Senkou Release-ban)", "priority": 2}
 			]
 		},
 		{
@@ -1544,6 +1558,13 @@
 			"titles": [
 				{"searchTerm": "Dot Hack G.U. Vol. 1 - Rebirth"},
 				{"searchTerm": "Dot Hack G.U. Vol. 1 - Saitan"}
+			]
+		},
+		{
+			"group": "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc",
+			"titles": [
+				{"searchTerm": "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc"},
+				{"searchTerm": "Dot Hack G.U. Terminal Disc - The End of The World"}
 			]
 		},
 		{
@@ -2956,10 +2977,9 @@
 		{
 			"group": "Hard Hitter Tennis",
 			"titles": [
-				{"searchTerm": "Centre Court - Hard Hitter"},
 				{"searchTerm": "Grand Slam 2003 Tennis"},
-				{"searchTerm": "Hard Hitter"},
-				{"searchTerm": "Hard Hitter Tennis"}
+				{"searchTerm": "Hard Hitter Tennis"},
+				{"searchTerm": "Hard Hitter 2"}
 			]
 		},
 		{
@@ -3943,6 +3963,13 @@
 			"titles": [
 				{"searchTerm": "Lowrider"},
 				{"searchTerm": "LowRider - Round the World"}
+			]
+		},
+		{
+			"group": "Lupin Sansei - Lupin ni wa Shi o, Zenigata ni wa Koi o",
+			"titles": [
+				{"searchTerm": "Lupin Sansei - Lupin ni wa Shi o, Zenigata ni wa Koi o"},
+				{"searchTerm": "Avventure di Lupin III, Le - Lupin la Morte, Zenigata l'Amore"}
 			]
 		},
 		{
@@ -6296,6 +6323,16 @@
 			]
 		},
 		{
+			"group": "Simple 2000 Series Vol. 90 - The OneeChambara 2",
+			"titles": [
+				{"searchTerm": "Simple 2000 Series Vol. 90 - The OneeChambara 2"}
+			],
+			"supersets": [
+				{"searchTerm": "Simple 2000 Series Vol. 101 - The OneeChampon - The Nee-chan 2 Tokubetsu-hen"},
+				{"searchTerm": "Zombie Hunters 2"}
+			]
+		},
+		{
 			"group": "Simple Outlaws DX Gaiden - Chou Saisoku! Zokusha King Bore Up - Butchigiri Densetsu 2",
 			"titles": [
 				{"searchTerm": "Simple Outlaws DX Gaiden - Chou Saisoku! Zokusha King Bore Up - Butchigiri Densetsu 2"}
@@ -7454,6 +7491,13 @@
 			]
 		},
 		{
+			"group": "Walt Disney Pictures Bolt",
+			"titles": [
+				{"searchTerm": "Walt Disney Pictures Bolt"},
+				{"searchTerm": "Disney Bolt"}
+			]
+		},
+		{
 			"group": "Walt Disney Pictures Presents Meet the Robinsons",
 			"titles": [
 				{"searchTerm": "Lewis to Mirai Dorobou - Wilbur no Kiken na Jikan Ryokou"},
@@ -7947,16 +7991,6 @@
 			]
 		},
 		{
-			"group": "Zombie Hunters 2",
-			"titles": [
-				{"searchTerm": "Simple 2000 Series Vol. 90 - The OneeChambara 2"},
-				{"searchTerm": "Zombie Hunters 2"}
-			],
-			"supersets": [
-				{"searchTerm": "Simple 2000 Series Vol. 101 - The OneeChampon - The Nee-chan 2 Tokubetsu-hen"}
-			]
-		},
-		{
 			"group": "Zombie Virus",
 			"titles": [
 				{"searchTerm": "Simple 2000 Series Vol. 95 - The Zombie vs. Kyuukyuusha"},
@@ -7969,6 +8003,10 @@
 				{"searchTerm": "Simple 2000 Series - The Chanbara"},
 				{"searchTerm": "Simple 2000 Series Vol. 61 - The OneeChambara"},
 				{"searchTerm": "Zombie Zone"}
+			],
+			"supersets": [
+				{"searchTerm": "Simple 2000 Series Vol. 80 - The OneeChamploo - The Nee-chan Tokubetsu-hen"},
+				{"searchTerm": "Zombie Zone - Other Side"}
 			]
 		},
 		{

--- a/clonelists/Sony - PlayStation 2 (Redump).json
+++ b/clonelists/Sony - PlayStation 2 (Redump).json
@@ -2384,13 +2384,6 @@
 			]
 		},
 		{
-			"group": "Flying Circus - RC Copter Adventure Championship (Propo-gata Controller Doukonban)",
-			"titles": [
-				{"searchTerm": "Flying Circus - RC Copter Adventure Championship (Propo-gata Controller Doukonban)"},
-				{"searchTerm": "Flying Circus - RC Copter Adventure Championship", "priority": 2}
-			]
-		},
-		{
 			"group": "Forbidden Siren 2",
 			"titles": [
 				{"searchTerm": "Forbidden Siren 2"},
@@ -3231,6 +3224,9 @@
 			"titles": [
 				{"searchTerm": "Hyper Street Fighter II - The Anniversary Edition (CapKore)"},
 				{"searchTerm": "Hyper Street Fighter II - The Anniversary Edition", "priority": 2}
+			],
+			"compilations": [
+				{"searchTerm": "Street Fighter Anniversary Collection"}
 			]
 		},
 		{
@@ -3501,6 +3497,13 @@
 			],
 			"supersets": [
 				{"searchTerm": "Kamen Rider Hibiki - Taiko no Tatsujin Special Version"}
+			]
+		},
+		{
+			"group": "Kanojo no Densetsu, Boku no Sekiban - Amirion no Ken to Tomo ni",
+			"titles": [
+				{"searchTerm": "Kanojo no Densetsu, Boku no Sekiban - Amirion no Ken to Tomo ni"},
+				{"searchTerm": "Simple 2000 Series Vol. 71 - The Fantasy Ren'ai Adventure - Kanojo no Densetsu, Boku no Sekiban", "priority": 2}
 			]
 		},
 		{
@@ -4133,6 +4136,26 @@
 			]
 		},
 		{
+			"group": "Matching Maker",
+			"titles": [
+				{"searchTerm": "Matching Maker"}
+			],
+			"supersets": [
+				{"searchTerm": "Metropolismania"},
+				{"searchTerm": "Simple 2000 Series Vol. 39 - The Boku no Machi-zukuri - Matching Maker++"}
+			]
+		},
+		{
+			"group": "Matching Maker 2 - Zoku Boku no Machi-zukuri",
+			"titles": [
+				{"searchTerm": "Matching Maker 2 - Zoku Boku no Machi-zukuri"}
+			],
+			"supersets": [
+				{"searchTerm": "Metropolismania 2"},
+				{"searchTerm": "Simple 2000 Series Vol. 121 - The Boku no Machi-zukuri 2 - Matching Maker 2.1"}
+			]
+		},
+		{
 			"group": "Maximo - Ghosts to Glory",
 			"titles": [
 				{"searchTerm": "Maximo"},
@@ -4390,21 +4413,6 @@
 			]
 		},
 		{
-			"group": "Metropolismania",
-			"titles": [
-				{"searchTerm": "Metropolismania"},
-				{"searchTerm": "Simple 2000 Series Vol. 39 - The Boku no Machi-zukuri - Matching Maker++"}
-			]
-		},
-		{
-			"group": "Metropolismania 2",
-			"titles": [
-				{"searchTerm": "Metropolismania 2"},
-				{"searchTerm": "Simple 2000 Series Vol. 121 - The Boku no Machi-zukuri 2 - Matching Maker 2.1"},
-				{"searchTerm": "Matching Maker 2 - Zoku Boku no Machi-zukuri", "priority": 2}
-			]
-		},
-		{
 			"group": "Michigan - Report from Hell",
 			"titles": [
 				{"searchTerm": "Michigan"},
@@ -4432,6 +4440,24 @@
 			],
 			"supersets": [
 				{"searchTerm": "Midnight Club 3 - DUB Edition Remix"}
+			]
+		},
+		{
+			"group": "Midway Arcade Treasures",
+			"titles": [
+				{"searchTerm": "Midway Arcade Treasures"}
+			],
+			"compilations": [
+				{"searchTerm": "Geesen USA - Midway Arcade Treasures"}
+			]
+		},
+		{
+			"group": "Midway Arcade Treasures 2",
+			"titles": [
+				{"searchTerm": "Midway Arcade Treasures 2"}
+			],
+			"compilations": [
+				{"searchTerm": "Geesen USA - Midway Arcade Treasures"}
 			]
 		},
 		{
@@ -4606,6 +4632,13 @@
 			"titles": [
 				{"searchTerm": "Golful Golf"},
 				{"searchTerm": "Mr. Golf"}
+			]
+		},
+		{
+			"group": "MS Saga - A New Dawn",
+			"titles": [
+				{"searchTerm": "Gundam True Odyssey - Ushinawareshi G no Densetsu"},
+				{"searchTerm": "MS Saga - A New Dawn"}
 			]
 		},
 		{
@@ -5484,6 +5517,14 @@
 				{"searchTerm": "Doukyuu - Billiard Master 2"},
 				{"searchTerm": "Pool Master"},
 				{"searchTerm": "Q-Ball - Billiards Master"}
+			]
+		},
+		{
+			"group": "R-C Sports Copter Challenge",
+			"titles": [
+				{"searchTerm": "Flying Circus - RC Copter Adventure Championship (Propo-gata Controller Doukonban)"},
+				{"searchTerm": "R-C Sports Copter Challenge"},
+				{"searchTerm": "Flying Circus - RC Copter Adventure Championship", "priority": 2}
 			]
 		},
 		{
@@ -6733,6 +6774,15 @@
 			]
 		},
 		{
+			"group": "Street Fighter III - 3rd Strike - Fight for the Future",
+			"titles": [
+				{"searchTerm": "Street Fighter III - 3rd Strike - Fight for the Future"}
+			],
+			"compilations": [
+				{"searchTerm": "Street Fighter Anniversary Collection"}
+			]
+		},
+		{
 			"group": "Street Golfer",
 			"titles": [
 				{"searchTerm": "Simple 2000 Series Ultimate Vol. 12 - Street Golfer"},
@@ -6796,6 +6846,9 @@
 				{"searchTerm": "Super Bust-A-Move"},
 				{"searchTerm": "Super Puzzle Bobble Collection (Disc 1)"},
 				{"searchTerm": "Super Puzzle Bobble", "priority": 2}
+			],
+			"compilations": [
+				{"searchTerm": "Simple 2000 Series Vol. 62 - The Super Puzzle Bobble DX"}
 			]
 		},
 		{
@@ -6804,6 +6857,9 @@
 				{"searchTerm": "Super Bust-A-Move 2"},
 				{"searchTerm": "Super Puzzle Bobble Collection (Disc 2)"},
 				{"searchTerm": "Super Puzzle Bobble 2", "priority": 2}
+			],
+			"compilations": [
+				{"searchTerm": "Simple 2000 Series Vol. 62 - The Super Puzzle Bobble DX"}
 			]
 		},
 		{
@@ -7045,6 +7101,13 @@
 			"titles": [
 				{"searchTerm": "Thing, The"},
 				{"searchTerm": "Yuusei kara no Buttai X - Episode II"}
+			]
+		},
+		{
+			"group": "Thread Colors - Sayonara no Mukougawa",
+			"titles": [
+				{"searchTerm": "Thread Colors - Sayonara no Mukougawa"},
+				{"searchTerm": "Simple 2000 Series Vol. 45 - The Koi to Namida to, Tsuioku to... Thread Colors - Sayonara no Mukougawa", "priority": 2}
 			]
 		},
 		{

--- a/clonelists/Sony - PlayStation 2 (Redump).json
+++ b/clonelists/Sony - PlayStation 2 (Redump).json
@@ -1563,8 +1563,8 @@
 		{
 			"group": "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc",
 			"titles": [
-				{"searchTerm": "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc"},
-				{"searchTerm": "Dot Hack G.U. Terminal Disc - The End of The World"}
+				{"searchTerm": "Dot Hack G.U. Terminal Disc - The End of The World"},
+				{"searchTerm": "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc"}
 			]
 		},
 		{
@@ -2971,8 +2971,8 @@
 			"group": "Hard Hitter Tennis",
 			"titles": [
 				{"searchTerm": "Grand Slam 2003 Tennis"},
-				{"searchTerm": "Hard Hitter Tennis"},
-				{"searchTerm": "Hard Hitter 2"}
+				{"searchTerm": "Hard Hitter 2"},
+				{"searchTerm": "Hard Hitter Tennis"}
 			]
 		},
 		{


### PR DESCRIPTION
## New clone groups/titles: 
- "Choro Q" 
- "Dot Hack G.U. Vol. 1 - Rebirth - Terminal Disc" 
- "Flying Circus - RC Copter Adventure Championship (Propo-gata Controller Doukonban)" 
- "Kanojo no Densetsu, Boku no Sekiban - Amirion no Ken to Tomo ni" 
- "Lupin Sansei - Lupin ni wa Shi o, Zenigata ni wa Koi o" 
- "MS Saga - A New Dawn" 
- "R-C Sports Copter Challenge" 
- "Thread Colors - Sayonara no Mukougawa" 
- "Walt Disney Pictures Bolt" 

## New compilations: 
- "Geesen USA - Midway Arcade Treasures" 
- "Street Fighter Anniversary Collection" 
- "Simple 2000 Series Vol. 62 - The Super Puzzle Bobble DX" 

## Untangling and corrections: 
- "Centre Court - Hard Hitter" and "Hard Hitter Tennis" are two different games, corrected based on personal testing and [Wikipedia](https://en.wikipedia.org/wiki/Hard_Hitter_Tennis) article 
- Downgraded priority of "Dot Hack Fraegment (Senkou Release-ban)" as it's a cut down pre-release version of the game ([source](https://archive.org/details/dot-hack-fragment-early-release-version)) 
- Reshuffle for "Matching Maker" and "Matching Maker 2" clone groups, using supersets to tie the improved Simple 2000 releases with the English localizations 
- Corrections for "Oneechanbara" series using supersets for updated versions, based off [Wikipedia](https://en.wikipedia.org/wiki/Onechanbara) and [Fandom](https://onechanbara.fandom.com/wiki/OneeChanbara_(franchise)) articles 